### PR TITLE
Add commissioner delete team functionality

### DIFF
--- a/app/league/[id]/league-home.tsx
+++ b/app/league/[id]/league-home.tsx
@@ -170,10 +170,6 @@ export default function LeagueHome({ teams, league_id, league, isCommissioner }:
                                 </p>
                             </div>
                             <div className="flex items-center space-x-4">
-                                <span className="text-secondary-text mr-2">Total Score:</span>
-                                <span className="text-liquid-lava font-bold text-lg">
-                                    {Number(team.totalScore).toFixed(1)}
-                                </span>
                                 {isCommissioner && !team.owner && (
                                     <button
                                         onClick={() => copyToClipboard(`${window.location.origin}/invite/team/${team.id}`)}
@@ -182,6 +178,10 @@ export default function LeagueHome({ teams, league_id, league, isCommissioner }:
                                         Copy Team Invite
                                     </button>
                                 )}
+                                <span className="text-secondary-text mr-2">Total Score:</span>
+                                <span className="text-liquid-lava font-bold text-lg">
+                                    {Number(team.totalScore).toFixed(1)}
+                                </span>
                             </div>
                         </div>
                     </div>

--- a/app/league/[id]/team/[teamid]/page.tsx
+++ b/app/league/[id]/team/[teamid]/page.tsx
@@ -120,7 +120,8 @@ export default async function Team(props: { params: Promise<{ teamid: TeamID }> 
     };
 
     const isOwner = user.id === team.user_id;
-    const isAuthorized = isOwner || user.id === team.leagues?.commish;
+    const isCommissioner = user.id === team.leagues?.commish;
+    const isAuthorized = isOwner || isCommissioner;
 
     const baseLayout = (content: React.ReactNode) => (
         <div className="min-h-screen bg-background">
@@ -148,7 +149,7 @@ export default async function Team(props: { params: Promise<{ teamid: TeamID }> 
     const mainContent = (
         <div className="p-6">
             <div className="mb-6">
-                <TeamHeader team={team} isAuthorized={isAuthorized} isOwner={isOwner} />
+                <TeamHeader team={team} isAuthorized={isAuthorized} isOwner={isOwner} isCommissioner={isCommissioner} />
                 <h2 className="text-secondary-text">{teamData.owner?.full_name || 'Unclaimed'}</h2>
             </div>
 

--- a/app/league/[id]/team/[teamid]/team-header.tsx
+++ b/app/league/[id]/team/[teamid]/team-header.tsx
@@ -1,19 +1,22 @@
 "use client";
 import { useState, useOptimistic, startTransition, useEffect } from 'react';
 import { createClient } from "../../../../utils/supabase/client";
-import { Edit2, Check, X, LogOut } from "lucide-react";
+import { Edit2, Check, X, LogOut, Trash2 } from "lucide-react";
 import { useRouter } from 'next/navigation';
 
 type TeamHeaderProps = {
     team: TeamWithRelations;
     isAuthorized: boolean;
     isOwner: boolean;
+    isCommissioner: boolean;
 };
 
-export default function TeamHeader({ team, isAuthorized, isOwner }: TeamHeaderProps) {
+export default function TeamHeader({ team, isAuthorized, isOwner, isCommissioner }: TeamHeaderProps) {
     const [isEditing, setIsEditing] = useState(false);
     const [isLeaving, setIsLeaving] = useState(false);
     const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
+    const [isDeleting, setIsDeleting] = useState(false);
+    const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const router = useRouter();
     const [optimisticTeam, updateOptimisticTeam] = useOptimistic<
         TeamWithRelations,
@@ -81,6 +84,26 @@ export default function TeamHeader({ team, isAuthorized, isOwner }: TeamHeaderPr
         }
     };
 
+    const [deleteError, setDeleteError] = useState<string | null>(null);
+
+    const handleDeleteTeam = async () => {
+        setIsDeleting(true);
+        setDeleteError(null);
+
+        const { error } = await supabase
+            .from('teams')
+            .delete()
+            .eq('id', team.id);
+
+        if (error) {
+            console.error('Error deleting team:', error);
+            setDeleteError(error.message);
+            setIsDeleting(false);
+        } else {
+            router.push(`/league/${team.league_id}`);
+        }
+    };
+
     // Handle the Enter key press
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter') {
@@ -139,6 +162,15 @@ export default function TeamHeader({ team, isAuthorized, isOwner }: TeamHeaderPr
                             <LogOut size={16} />
                         </button>
                     )}
+                    {isCommissioner && (
+                        <button
+                            onClick={() => setShowDeleteConfirm(true)}
+                            className="text-red-500 hover:text-red-400 transition-colors"
+                            aria-label="Delete team"
+                        >
+                            <Trash2 size={16} />
+                        </button>
+                    )}
                 </div>
             )}
 
@@ -163,6 +195,41 @@ export default function TeamHeader({ team, isAuthorized, isOwner }: TeamHeaderPr
                                 className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors disabled:opacity-50"
                             >
                                 {isLeaving ? 'Leaving...' : 'Leave Team'}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {showDeleteConfirm && (
+                <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+                    <div className="bg-surface border border-border rounded-lg p-6 max-w-sm mx-4">
+                        <h3 className="text-lg font-bold text-primary-text mb-2">Delete Team?</h3>
+                        <p className="text-secondary-text mb-4">
+                            Are you sure you want to permanently delete {team.name}? This action cannot be undone.
+                        </p>
+                        {deleteError && (
+                            <div className="text-red-500 text-sm p-2 bg-red-100/10 rounded mb-4">
+                                {deleteError}
+                            </div>
+                        )}
+                        <div className="flex justify-end space-x-3">
+                            <button
+                                onClick={() => {
+                                    setShowDeleteConfirm(false);
+                                    setDeleteError(null);
+                                }}
+                                className="px-4 py-2 text-secondary-text hover:text-primary-text transition-colors"
+                                disabled={isDeleting}
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                onClick={handleDeleteTeam}
+                                disabled={isDeleting}
+                                className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors disabled:opacity-50"
+                            >
+                                {isDeleting ? 'Deleting...' : 'Delete Team'}
                             </button>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Add delete team button (trash icon) on team page, visible only to commissioners
- Add confirmation modal with permanent deletion warning and error display
- Move copy team invite button to left of total score on league page

**Note:** Requires RLS policy in Supabase to allow commissioners to delete teams:
```sql
CREATE POLICY "Commissioners can delete teams in their leagues"
ON teams
FOR DELETE
TO authenticated
USING (
  league_id IN (
    SELECT id FROM leagues WHERE commish = auth.uid()
  )
);
```

## Test plan
- [x] As commissioner, visit a team page and verify delete button (trash icon) appears
- [x] Click delete, verify confirmation modal appears with warning
- [x] Confirm deletion, verify team is removed and redirected to league page
- [x] As non-commissioner, verify delete button does NOT appear
- [x] On league page, verify copy team invite button appears to left of total score

🤖 Generated with [Claude Code](https://claude.ai/code)