### PR TITLE
Refactor draft to server-authoritative RPC flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Fanteasy is a fantasy sports league application supporting NFL, NBA, and NCAAM l
 - `migration2026/` - Data migration utilities
 
 ### Core Features
-- **Draft System** (`app/draft/[id]/`) - Real-time snake/linear draft with auto-pick, queue, timer
+- **Draft System** (`app/draft/[id]/`) - Real-time snake/linear draft with auto-pick, queue, server-authoritative timer
 - **League Management** (`app/league/[id]/`) - Teams, standings, scoring
 - **Weekly Picks** (`app/league/[id]/`) - Playoff lineup selection with position slots, cross-week duplicate prevention, and lock management
 - **Authentication** (`app/login/`, `middleware.ts`) - Supabase Auth with Google OAuth, Google One-Tap, and magic links
@@ -61,6 +61,15 @@ Uses CSS custom properties with `data-theme` attribute on `<html>`:
 Required in `.env.local`:
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+
+## Draft System Architecture
+
+All draft mutations go through Server Actions (`app/draft/[id]/actions.ts`) calling the `make_draft_pick` Postgres RPC — **do NOT add direct client-side writes to `draft_picks` or `draft_settings`**.
+
+- **Timer**: Server-authoritative via `timer_started_at` column on `draft_settings`, broadcast to clients via Realtime. The client timer (`draft-timer.tsx`) derives remaining time from this timestamp.
+- **Auto-pick**: The `auto_pick_expired_drafts()` PG function is designed to run via `pg_cron` (every 5s). If pg_cron is unavailable, use the `/api/draft/auto-pick` route as a fallback (called client-side when the timer expires).
+- **Commissioner**: Can pick for any team during that team's turn. The turn check lives in both `actions.ts` (server action layer) and the `make_draft_pick` RPC (DB layer).
+- **RLS TODO**: Direct-write RLS policies on `draft_picks` and `draft_settings` are intentionally permissive while the RPC flow is being validated. See `documentation/TODO-rls-policies.md` for the tightening plan before production.
 
 ## Python Scrapers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,13 +21,17 @@ Fanteasy is a fantasy sports league application supporting NFL, NBA, and NCAAM l
 - `app/` - Next.js App Router pages and components (colocated by feature)
 - `app/utils/supabase/` - Supabase client utilities (server.ts, client.ts, middleware.ts)
 - `app/utils/scoring.ts` - Fantasy points calculation for NFL/NBA
+- `app/global.d.ts` - Extended relationship types (TeamWithLeague, DraftPickWithDetails, etc.)
 - `lib/database.types.ts` - Auto-generated Supabase TypeScript types
 - `documentation/` - Feature and development docs
+- `scrapers/` - Python data scrapers for NFL, NBA, and NCAA
+- `migration2026/` - Data migration utilities
 
 ### Core Features
 - **Draft System** (`app/draft/[id]/`) - Real-time snake/linear draft with auto-pick, queue, timer
 - **League Management** (`app/league/[id]/`) - Teams, standings, scoring
-- **Authentication** (`app/login/`, `middleware.ts`) - Supabase Auth with Google OAuth and magic links
+- **Weekly Picks** (`app/league/[id]/`) - Playoff lineup selection with position slots, cross-week duplicate prevention, and lock management
+- **Authentication** (`app/login/`, `middleware.ts`) - Supabase Auth with Google OAuth, Google One-Tap, and magic links
 
 ### Database Tables
 Key tables: `leagues`, `teams`, `players`, `profiles`, `game_stats`, `draft_settings`, `draft_picks`, `draft_queue`, `weekly_picks`
@@ -50,6 +54,7 @@ Uses CSS custom properties with `data-theme` attribute on `<html>`:
 - Dark mode (default): `--background`, `--surface`, `--primary-text` etc.
 - Light mode: `html[data-theme="light"]` overrides
 - Theme state persisted in localStorage
+- Custom Tailwind colors defined in `tailwind.config.ts`: liquid-lava, dark-void, snow, dusty-grey, gluon-grey, slate-grey
 
 ## Environment Variables
 
@@ -62,4 +67,6 @@ Required in `.env.local`:
 Use `uv` to run Python scripts in the `scrapers/` directory:
 ```bash
 uv run python scrapers/nfl/nfl-playoffs-scraper.py
+uv run python scrapers/nba/add-new-players.py
+uv run python scrapers/ncaa/ncaa-update-scores.py
 ```

--- a/app/api/draft/auto-pick/route.ts
+++ b/app/api/draft/auto-pick/route.ts
@@ -4,110 +4,78 @@ import { NextRequest, NextResponse } from 'next/server';
 export async function POST(req: NextRequest) {
     try {
         const { draftId, teamId } = await req.json();
-        
+
         if (!draftId || !teamId) {
             return NextResponse.json(
                 { error: 'Missing required parameters: draftId and teamId' },
                 { status: 400 }
             );
         }
-        
+
         const supabase = await createClient();
-        
+
         // Check if the team has auto-pick enabled
         const { data: teamData, error: teamError } = await supabase
             .from('teams')
             .select('auto_pick_preference')
             .eq('id', teamId)
             .single();
-            
+
         if (teamError) {
             return NextResponse.json(
                 { error: 'Error fetching team data', details: teamError.message },
                 { status: 500 }
             );
         }
-        
+
         if (!teamData.auto_pick_preference) {
             return NextResponse.json(
                 { success: false, message: 'Auto-pick is disabled for this team' },
                 { status: 200 }
             );
         }
-        
-        // Get draft settings to make sure it's still this team's turn
-        const { data: draftSettings, error: draftError } = await supabase
-            .from('draft_settings')
-            .select('*, leagues(*)')
-            .eq('id', draftId)
-            .single();
-            
-        if (draftError) {
-            return NextResponse.json(
-                { error: 'Error fetching draft settings', details: draftError.message },
-                { status: 500 }
-            );
-        }
-        
-        // Get current team's ID from the pick order based on current pick
-        const pickOrder = draftSettings.pick_order?.order || [];
-        const totalTeams = pickOrder.length;
-        
-        if (totalTeams === 0) {
-            return NextResponse.json(
-                { error: 'Invalid pick order' },
-                { status: 400 }
-            );
-        }
-        
-        const currentPickIndex = (draftSettings.current_pick - 1) % totalTeams;
-        const currentTeamId = pickOrder[currentPickIndex];
-        
-        // Verify it's still this team's turn
-        if (currentTeamId !== teamId) {
-            return NextResponse.json(
-                { success: false, message: 'Not this team\'s turn anymore' },
-                { status: 200 }
-            );
-        }
-        
-        // Try to use the database function for auto-picking
+
+        // Use auto_pick_player RPC to select best available player
         const { data: selectedPlayerId, error: functionError } = await supabase
             .rpc('auto_pick_player', { draft_id: draftId, team_id: teamId });
-            
+
         if (functionError) {
             return NextResponse.json(
                 { error: 'Error calling auto_pick_player function', details: functionError.message },
                 { status: 500 }
             );
         }
-        
+
         if (!selectedPlayerId) {
             return NextResponse.json(
                 { error: 'No available player found for auto-pick' },
                 { status: 404 }
             );
         }
-        
-        // Make the draft pick with is_auto_pick set to true
-        const { error: pickError } = await supabase
-            .from('draft_picks')
-            .insert({
-                draft_id: draftId,
-                team_id: teamId,
-                player_id: selectedPlayerId,
-                pick_number: draftSettings.current_pick,
-                round_number: draftSettings.current_round,
-                is_auto_pick: true
-            });
-            
-        if (pickError) {
+
+        // Use atomic make_draft_pick RPC instead of direct insert
+        const { data: result, error: rpcError } = await supabase.rpc('make_draft_pick', {
+            p_draft_id: draftId,
+            p_team_id: teamId,
+            p_player_id: selectedPlayerId,
+            p_is_auto_pick: true,
+        });
+
+        if (rpcError) {
             return NextResponse.json(
-                { error: 'Error making auto-pick', details: pickError.message },
+                { error: 'Error making auto-pick', details: rpcError.message },
                 { status: 500 }
             );
         }
-        
+
+        const rpcResult = result as any;
+        if (!rpcResult?.success) {
+            return NextResponse.json(
+                { error: rpcResult?.error || 'Auto-pick failed' },
+                { status: 400 }
+            );
+        }
+
         return NextResponse.json({ success: true, playerId: selectedPlayerId });
     } catch (error: any) {
         console.error('Auto-pick error:', error);

--- a/app/draft/[id]/actions.ts
+++ b/app/draft/[id]/actions.ts
@@ -1,0 +1,278 @@
+'use server';
+
+import { createClient } from '@/app/utils/supabase/server';
+
+interface ActionResult {
+    success: boolean;
+    error?: string;
+    data?: any;
+}
+
+export async function makePick(draftId: string, playerId: string): Promise<ActionResult> {
+    const supabase = await createClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+        return { success: false, error: 'Not authenticated' };
+    }
+
+    // Get draft settings to find the league
+    const { data: draft, error: draftError } = await supabase
+        .from('draft_settings')
+        .select('league_id, pick_order, current_pick, current_round, draft_type')
+        .eq('id', draftId)
+        .single();
+
+    if (draftError || !draft) {
+        return { success: false, error: 'Draft not found' };
+    }
+
+    // Get user's team in this league
+    const { data: team, error: teamError } = await supabase
+        .from('teams')
+        .select('id')
+        .eq('league_id', draft.league_id)
+        .eq('user_id', user.id)
+        .single();
+
+    if (teamError || !team) {
+        // Check if user is commissioner (can pick for current team)
+        const { data: league } = await supabase
+            .from('leagues')
+            .select('commish')
+            .eq('id', draft.league_id)
+            .single();
+
+        if (!league || league.commish !== user.id) {
+            return { success: false, error: 'No team found in this league' };
+        }
+
+        // Commissioner picks on behalf of the current team
+        const pickOrder = (draft.pick_order as any)?.order || [];
+        const totalTeams = pickOrder.length;
+        if (totalTeams === 0) {
+            return { success: false, error: 'Invalid pick order' };
+        }
+
+        const currentIndex = ((draft.current_pick! - 1) % totalTeams);
+        const isSnake = draft.draft_type === 'snake';
+        const isEvenRound = draft.current_round! % 2 === 0;
+
+        let currentTeamId: string;
+        if (isSnake && isEvenRound) {
+            currentTeamId = pickOrder[totalTeams - 1 - currentIndex];
+        } else {
+            currentTeamId = pickOrder[currentIndex];
+        }
+
+        const { data: result, error: rpcError } = await supabase.rpc('make_draft_pick', {
+            p_draft_id: draftId,
+            p_team_id: currentTeamId,
+            p_player_id: playerId,
+            p_is_auto_pick: false,
+        });
+
+        if (rpcError) {
+            return { success: false, error: rpcError.message };
+        }
+
+        const rpcResult = result as any;
+        if (!rpcResult?.success) {
+            return { success: false, error: rpcResult?.error || 'Pick failed' };
+        }
+
+        return { success: true, data: rpcResult };
+    }
+
+    // Regular user making a pick
+    const { data: result, error: rpcError } = await supabase.rpc('make_draft_pick', {
+        p_draft_id: draftId,
+        p_team_id: team.id,
+        p_player_id: playerId,
+        p_is_auto_pick: false,
+    });
+
+    if (rpcError) {
+        return { success: false, error: rpcError.message };
+    }
+
+    const rpcResult = result as any;
+    if (!rpcResult?.success) {
+        return { success: false, error: rpcResult?.error || 'Pick failed' };
+    }
+
+    return { success: true, data: rpcResult };
+}
+
+export async function startDraft(draftId: string): Promise<ActionResult> {
+    const supabase = await createClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+        return { success: false, error: 'Not authenticated' };
+    }
+
+    // Verify commissioner
+    const { data: draft } = await supabase
+        .from('draft_settings')
+        .select('league_id')
+        .eq('id', draftId)
+        .single();
+
+    if (!draft) {
+        return { success: false, error: 'Draft not found' };
+    }
+
+    const { data: league } = await supabase
+        .from('leagues')
+        .select('commish')
+        .eq('id', draft.league_id)
+        .single();
+
+    if (!league || league.commish !== user.id) {
+        return { success: false, error: 'Only the commissioner can start the draft' };
+    }
+
+    const { error } = await supabase
+        .from('draft_settings')
+        .update({
+            draft_status: 'in_progress',
+            timer_started_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+        })
+        .eq('id', draftId);
+
+    if (error) {
+        return { success: false, error: error.message };
+    }
+
+    return { success: true };
+}
+
+export async function togglePause(draftId: string): Promise<ActionResult> {
+    const supabase = await createClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+        return { success: false, error: 'Not authenticated' };
+    }
+
+    // Verify commissioner
+    const { data: draft } = await supabase
+        .from('draft_settings')
+        .select('league_id, is_paused')
+        .eq('id', draftId)
+        .single();
+
+    if (!draft) {
+        return { success: false, error: 'Draft not found' };
+    }
+
+    const { data: league } = await supabase
+        .from('leagues')
+        .select('commish')
+        .eq('id', draft.league_id)
+        .single();
+
+    if (!league || league.commish !== user.id) {
+        return { success: false, error: 'Only the commissioner can pause/resume the draft' };
+    }
+
+    const newPausedState = !draft.is_paused;
+
+    const updateData: any = {
+        is_paused: newPausedState,
+        updated_at: new Date().toISOString(),
+    };
+
+    // Reset timer on resume
+    if (!newPausedState) {
+        updateData.timer_started_at = new Date().toISOString();
+    } else {
+        updateData.timer_started_at = null;
+    }
+
+    const { error } = await supabase
+        .from('draft_settings')
+        .update(updateData)
+        .eq('id', draftId);
+
+    if (error) {
+        return { success: false, error: error.message };
+    }
+
+    return { success: true, data: { isPaused: newPausedState } };
+}
+
+export async function toggleAutoPick(teamId: string): Promise<ActionResult> {
+    const supabase = await createClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+        return { success: false, error: 'Not authenticated' };
+    }
+
+    // Verify user owns this team
+    const { data: team } = await supabase
+        .from('teams')
+        .select('id, user_id, auto_pick_preference')
+        .eq('id', teamId)
+        .single();
+
+    if (!team) {
+        return { success: false, error: 'Team not found' };
+    }
+
+    if (team.user_id !== user.id) {
+        return { success: false, error: 'You do not own this team' };
+    }
+
+    const newValue = !team.auto_pick_preference;
+
+    const { error } = await supabase
+        .from('teams')
+        .update({ auto_pick_preference: newValue })
+        .eq('id', teamId);
+
+    if (error) {
+        return { success: false, error: error.message };
+    }
+
+    return { success: true, data: { autoPickEnabled: newValue } };
+}
+
+export async function triggerAutoPick(draftId: string, teamId: string): Promise<ActionResult> {
+    const supabase = await createClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+        return { success: false, error: 'Not authenticated' };
+    }
+
+    // Get auto-pick player from existing RPC
+    const { data: selectedPlayerId, error: autoPickError } = await supabase
+        .rpc('auto_pick_player', { draft_id: draftId, team_id: teamId });
+
+    if (autoPickError || !selectedPlayerId) {
+        return { success: false, error: autoPickError?.message || 'No available player for auto-pick' };
+    }
+
+    // Use the atomic make_draft_pick RPC
+    const { data: result, error: rpcError } = await supabase.rpc('make_draft_pick', {
+        p_draft_id: draftId,
+        p_team_id: teamId,
+        p_player_id: selectedPlayerId,
+        p_is_auto_pick: true,
+    });
+
+    if (rpcError) {
+        return { success: false, error: rpcError.message };
+    }
+
+    const rpcResult = result as any;
+    if (!rpcResult?.success) {
+        return { success: false, error: rpcResult?.error || 'Auto-pick failed' };
+    }
+
+    return { success: true, data: rpcResult };
+}

--- a/app/draft/[id]/actions.ts
+++ b/app/draft/[id]/actions.ts
@@ -27,6 +27,15 @@ export async function makePick(draftId: string, playerId: string): Promise<Actio
         return { success: false, error: 'Draft not found' };
     }
 
+    // Check if user is commissioner
+    const { data: league } = await supabase
+        .from('leagues')
+        .select('commish')
+        .eq('id', draft.league_id)
+        .single();
+
+    const isCommissioner = league?.commish === user.id;
+
     // Get user's team in this league
     const { data: team, error: teamError } = await supabase
         .from('teams')
@@ -35,59 +44,44 @@ export async function makePick(draftId: string, playerId: string): Promise<Actio
         .eq('user_id', user.id)
         .single();
 
-    if (teamError || !team) {
-        // Check if user is commissioner (can pick for current team)
-        const { data: league } = await supabase
-            .from('leagues')
-            .select('commish')
-            .eq('id', draft.league_id)
-            .single();
-
-        if (!league || league.commish !== user.id) {
-            return { success: false, error: 'No team found in this league' };
-        }
-
-        // Commissioner picks on behalf of the current team
-        const pickOrder = (draft.pick_order as any)?.order || [];
-        const totalTeams = pickOrder.length;
-        if (totalTeams === 0) {
-            return { success: false, error: 'Invalid pick order' };
-        }
-
+    // Calculate current team from pick order
+    const pickOrder = (draft.pick_order as any)?.order || [];
+    const totalTeams = pickOrder.length;
+    
+    let currentTeamId: string | null = null;
+    if (totalTeams > 0) {
         const currentIndex = ((draft.current_pick! - 1) % totalTeams);
         const isSnake = draft.draft_type === 'snake';
         const isEvenRound = draft.current_round! % 2 === 0;
 
-        let currentTeamId: string;
         if (isSnake && isEvenRound) {
             currentTeamId = pickOrder[totalTeams - 1 - currentIndex];
         } else {
             currentTeamId = pickOrder[currentIndex];
         }
-
-        const { data: result, error: rpcError } = await supabase.rpc('make_draft_pick', {
-            p_draft_id: draftId,
-            p_team_id: currentTeamId,
-            p_player_id: playerId,
-            p_is_auto_pick: false,
-        });
-
-        if (rpcError) {
-            return { success: false, error: rpcError.message };
-        }
-
-        const rpcResult = result as any;
-        if (!rpcResult?.success) {
-            return { success: false, error: rpcResult?.error || 'Pick failed' };
-        }
-
-        return { success: true, data: rpcResult };
     }
 
-    // Regular user making a pick
+    // Determine which team to pick for
+    let pickingTeamId: string;
+    
+    if (team && team.id === currentTeamId) {
+        // It's the user's turn - pick for their own team
+        pickingTeamId = team.id;
+    } else if (isCommissioner && currentTeamId) {
+        // Commissioner picking for the current team (not their turn)
+        pickingTeamId = currentTeamId;
+    } else if (!team && isCommissioner && currentTeamId) {
+        // Commissioner with no team - pick for current team
+        pickingTeamId = currentTeamId;
+    } else if (!team) {
+        return { success: false, error: 'No team found in this league' };
+    } else {
+        return { success: false, error: 'Not your turn to pick' };
+    }
+
     const { data: result, error: rpcError } = await supabase.rpc('make_draft_pick', {
         p_draft_id: draftId,
-        p_team_id: team.id,
+        p_team_id: pickingTeamId,
         p_player_id: playerId,
         p_is_auto_pick: false,
     });

--- a/app/draft/[id]/draft-room.tsx
+++ b/app/draft/[id]/draft-room.tsx
@@ -490,6 +490,8 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                                 }
                             }}
                             isMyTurn={isMyTurn}
+                            isCommissioner={isCommissioner}
+                            isDraftActive={isDraftActive}
                             selectedPlayer={selectedPlayer}
                             leagueType={draftSettings.leagues.league}
                         />

--- a/app/draft/[id]/draft-room.tsx
+++ b/app/draft/[id]/draft-room.tsx
@@ -367,9 +367,11 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                                 </div>
                             </div>
 
-                            {isMyTurn && (
+                            {(isMyTurn || (isCommissioner && isDraftActive)) && (
                                 <div className="mt-4 pt-4 border-t border-slate-grey">
-                                    <p className="text-primary-text font-bold text-lg mb-2">It&apos;s Your Turn to Draft!</p>
+                                    <p className="text-primary-text font-bold text-lg mb-2">
+                                        {isMyTurn ? "It's Your Turn to Draft!" : "Commissioner Pick"}
+                                    </p>
 
                                     {pickError && (
                                         <p className="text-red-500 text-sm mb-2">{pickError}</p>

--- a/app/draft/[id]/draft-room.tsx
+++ b/app/draft/[id]/draft-room.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useTransition } from 'react';
 import Image from 'next/image';
 import { createClient } from '@/app/utils/supabase/client';
 import DraftQueue from './draft-queue';
@@ -8,9 +8,10 @@ import DraftHistory from './draft-history';
 import PlayerSearch from './player-search';
 import DraftTimer from './draft-timer';
 import TeamPicker from './team-picker';
+import { makePick, startDraft, togglePause, toggleAutoPick, triggerAutoPick } from './actions';
 
 interface DraftRoomProps {
-    draftSettings: any; // Using any here because we're mixing DB types with joins
+    draftSettings: any;
     currentTeam: any;
     isCommissioner: boolean;
     leagueTeams?: any[];
@@ -18,26 +19,7 @@ interface DraftRoomProps {
 
 export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, leagueTeams = [] }: DraftRoomProps) {
     const supabase = createClient();
-    
-    // Helper function to ensure player data has proper IDs
-    const sanitizePlayerData = (player: any) => {
-        if (!player) return player;
-        
-        // Create a new object to avoid mutating the original
-        const sanitized = { ...player };
-        
-        // Ensure ID is a string
-        if (sanitized.id) {
-            if (typeof sanitized.id === 'object') {
-                sanitized.id = String((sanitized.id as any).id || JSON.stringify(sanitized.id));
-            } else {
-                sanitized.id = String(sanitized.id);
-            }
-        }
-        
-        return sanitized;
-    };
-    
+
     // Draft state
     const [draftState, setDraftState] = useState(draftSettings);
     const [draftPicks, setDraftPicks] = useState<any[]>([]);
@@ -48,35 +30,46 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
     const [selectedPlayer, setSelectedPlayer] = useState<any>(null);
     const [autoPickEnabled, setAutoPickEnabled] = useState<boolean>(true);
     const [isPaused, setIsPaused] = useState<boolean>(draftSettings.is_paused || false);
-    
+    const [pickError, setPickError] = useState<string | null>(null);
+    const [isPending, startTransition] = useTransition();
+
     // Get current pick team information
     useEffect(() => {
         const fetchCurrentPickTeam = async () => {
             if (!draftState.pick_order) return;
-            
+
             const pickOrder = draftState.pick_order.order || [];
             if (pickOrder.length === 0) return;
-            
-            const currentPickIndex = (draftState.current_pick - 1) % pickOrder.length;
-            const currentTeamId = pickOrder[currentPickIndex];
-            
+
+            const totalTeams = pickOrder.length;
+            const currentIndex = (draftState.current_pick - 1) % totalTeams;
+            const isSnake = draftState.draft_type === 'snake';
+            const isEvenRound = draftState.current_round % 2 === 0;
+
+            let currentTeamId: string;
+            if (isSnake && isEvenRound) {
+                currentTeamId = pickOrder[totalTeams - 1 - currentIndex];
+            } else {
+                currentTeamId = pickOrder[currentIndex];
+            }
+
             try {
                 const { data: teamData, error } = await supabase
                     .from('teams')
                     .select('*, profiles(full_name)')
                     .eq('id', currentTeamId)
                     .single();
-                
+
                 if (error) throw error;
                 setCurrentPickTeam(teamData);
             } catch (error) {
                 console.error('Error fetching current pick team:', error);
             }
         };
-        
+
         fetchCurrentPickTeam();
-    }, [draftState.current_pick, draftState.pick_order, supabase]);
-    
+    }, [draftState.current_pick, draftState.current_round, draftState.pick_order, draftState.draft_type, supabase]);
+
     // Load draft picks
     useEffect(() => {
         const fetchDraftPicks = async () => {
@@ -86,32 +79,31 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                     .select('*, team:teams(name, id), player:players(name, position, team_name, pic_url, summary)')
                     .eq('draft_id', draftSettings.id)
                     .order('pick_number', { ascending: true });
-                
+
                 if (error) throw error;
                 setDraftPicks(data || []);
             } catch (error) {
                 console.error('Error fetching draft picks:', error);
             }
         };
-        
+
         fetchDraftPicks();
     }, [draftSettings.id, supabase]);
-    
+
     // Fetch current team's auto-pick preference
     useEffect(() => {
         const fetchAutoPickPreference = async () => {
             if (!currentTeam || currentTeam.id === 'commissioner') return;
-            
+
             try {
                 const { data, error } = await supabase
                     .from('teams')
                     .select('auto_pick_preference')
                     .eq('id', currentTeam.id)
                     .single();
-                
+
                 if (error) throw error;
-                
-                // Set the auto-pick preference from the database
+
                 if (data && typeof data.auto_pick_preference === 'boolean') {
                     setAutoPickEnabled(data.auto_pick_preference);
                 }
@@ -119,59 +111,52 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                 console.error('Error fetching auto-pick preference:', error);
             }
         };
-        
+
         fetchAutoPickPreference();
     }, [currentTeam, supabase]);
-    
+
     // Load available players
     useEffect(() => {
         const fetchAvailablePlayers = async () => {
             setIsLoading(true);
             try {
-                // Get already drafted players
                 const { data: draftedPlayers, error: draftedError } = await supabase
                     .from('draft_picks')
                     .select('player_id')
                     .eq('draft_id', draftSettings.id);
-                
+
                 if (draftedError) throw draftedError;
-                
-                // Get available players excluding drafted ones
+
                 const draftedIds = (draftedPlayers || []).map(pick => pick.player_id);
-                
+
                 let playersQuery = supabase
                     .from('players')
                     .select('*')
                     .eq('league', draftSettings.leagues.league)
                     .order('name');
-                    
-                // Only add the 'not in' filter if there are drafted players
+
                 if (draftedIds.length > 0) {
                     playersQuery = playersQuery.not('id', 'in', `(${draftedIds.join(',')})`);
                 }
-                
+
                 const { data: players, error: playersError } = await playersQuery;
-                
+
                 if (playersError) throw playersError;
-                
-                // Sanitize player data to ensure proper ID formatting
-                const sanitizedPlayers = players ? players.map(player => sanitizePlayerData(player)) : [];
-                
-                setAvailablePlayers(sanitizedPlayers);
-                setSearchResults(sanitizedPlayers);
+
+                setAvailablePlayers(players || []);
+                setSearchResults(players || []);
             } catch (error) {
                 console.error('Error fetching available players:', error);
             } finally {
                 setIsLoading(false);
             }
         };
-        
+
         fetchAvailablePlayers();
     }, [draftSettings.id, draftSettings.leagues.league, draftPicks.length, supabase]);
-    
+
     // Subscribe to draft changes
     useEffect(() => {
-        // Function to fetch latest draft picks
         const fetchLatestDraftPicks = async () => {
             try {
                 const { data, error } = await supabase
@@ -179,7 +164,7 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                     .select('*, team:teams(name, id), player:players(name, position, team_name, pic_url, summary)')
                     .eq('draft_id', draftSettings.id)
                     .order('pick_number', { ascending: true });
-                
+
                 if (error) throw error;
                 setDraftPicks(data || []);
             } catch (error) {
@@ -187,7 +172,6 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
             }
         };
 
-        // Subscribe to draft settings changes
         const draftChannel = supabase
             .channel('draft-room')
             .on('postgres_changes', {
@@ -197,7 +181,6 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                 filter: `id=eq.${draftSettings.id}`
             }, (payload) => {
                 setDraftState(payload.new);
-                // Also update the isPaused state when draft settings change
                 setIsPaused(payload.new.is_paused || false);
             })
             .on('postgres_changes', {
@@ -206,218 +189,68 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                 table: 'draft_picks',
                 filter: `draft_id=eq.${draftSettings.id}`
             }, () => {
-                // Refresh draft picks when a new pick is made
                 fetchLatestDraftPicks();
             })
             .subscribe();
-            
+
         return () => {
             supabase.removeChannel(draftChannel);
         };
     }, [draftSettings.id, supabase]);
-    
-    // Function to make a draft pick
-    const makeDraftPick = async (playerId: string) => {
-        console.log('Starting makeDraftPick function');
-        console.log('Parameters:', { playerId });
-        console.log('State:', { 
-            currentPickTeam: currentPickTeam ? { id: currentPickTeam.id, name: currentPickTeam.name } : null,
-            currentTeam: currentTeam ? { id: currentTeam.id, name: currentTeam.name } : null,
-            draftState: { status: draftState.draft_status, current_pick: draftState.current_pick, current_round: draftState.current_round },
-            draftSettings: { id: draftSettings.id }
-        });
-        
-        if (!currentPickTeam) {
-            console.error('currentPickTeam is null or undefined');
-            alert("Cannot make draft pick: system cannot determine whose turn it is.");
-            return;
-        }
-        
-        const isMyTurn = currentPickTeam.id === currentTeam.id;
-        const canMakePick = isMyTurn || (isCommissioner && draftState.draft_status === 'in_progress');
-        
-        if (!canMakePick) {
-            console.log("Not user's turn to draft", { isMyTurn, isCommissioner, draftStatus: draftState.draft_status });
-            alert("It's not your turn to draft.");
-            return;
-        }
-        
-        try {
-            if (!playerId) {
-                console.error('Invalid player ID:', playerId);
-                alert('Invalid player ID. Please select a player and try again.');
-                return;
-            }
-            
-            // Force playerId to be a simple string - this handles both object cases and string cases
-            let playerIdString: string;
-            
-            if (typeof playerId === 'string') {
-                // Handle string case - ensure it's a clean string with no JSON
-                try {
-                    // Check if it's a JSON string
-                    if (playerId.includes('{') || playerId.includes('[')) {
-                        const parsed = JSON.parse(playerId);
-                        playerIdString = typeof parsed === 'object' && parsed.id ? String(parsed.id) : String(playerId);
-                    } else {
-                        playerIdString = playerId; 
-                    }
-                } catch (e) {
-                    // If JSON parsing fails, use the string as is
-                    playerIdString = playerId;
-                }
-            } else if (typeof playerId === 'object' && playerId !== null) {
-                // Handle object case
-                playerIdString = (playerId as any).id ? String((playerId as any).id) : String(playerId);
+
+    // Server Action handlers
+    const handleMakePick = (playerId: string) => {
+        setPickError(null);
+        startTransition(async () => {
+            const result = await makePick(draftSettings.id, playerId);
+            if (!result.success) {
+                setPickError(result.error || 'Failed to make pick');
             } else {
-                // Fallback for other cases
-                playerIdString = String(playerId);
+                setSelectedPlayer(null);
+                setPickError(null);
             }
-            
-            // Additional safety check
-            if (playerIdString === '[object Object]' || playerIdString.includes('{')) {
-                console.error('Failed to extract proper player ID string from:', playerId);
-                alert('Invalid player ID format. Please try selecting a different player.');
-                return;
-            }
-            
-            const draft_id = draftSettings.id;
-            const team_id = currentPickTeam.id;
-            const pick_number = draftState.current_pick;
-            const round_number = draftState.current_round;
-            
-            console.log('Making draft pick with:', {
-                draft_id,
-                team_id,
-                player_id: playerIdString,
-                pick_number,
-                round_number
-            });
-            
-            // Verify data types before insert
-            console.log('Data types:', {
-                draft_id_type: typeof draft_id,
-                team_id_type: typeof team_id,
-                player_id_type: typeof playerIdString,
-                player_id_value: playerIdString,
-                pick_number_type: typeof pick_number,
-                round_number_type: typeof round_number
-            });
-            
-            // Create a properly typed object for the insert
-            const insertData = {
-                draft_id: draft_id.toString(),
-                team_id: team_id.toString(),
-                player_id: playerIdString,
-                pick_number: Number(pick_number),
-                round_number: Number(round_number),
-                is_auto_pick: false
-            };
-            
-            console.log('Final insert data:', insertData);
-            
-            // Remove the .select() call to simplify the operation
-            const { error } = await supabase
-                .from('draft_picks')
-                .insert(insertData);
-                
-            if (error) {
-                console.error('Supabase error making draft pick:', error);
-                console.error('Error details:', { 
-                    error, 
-                    message: error.message,
-                    details: error.details,
-                    hint: error.hint,
-                    code: error.code,
-                    // Log the actual values we tried to insert
-                    insertValues: insertData  // Use insertData directly here
-                });
-                throw error;
-            }
-            
-            console.log('Draft pick successful!');
-            
-            // Clear selected player
-            setSelectedPlayer(null);
-        } catch (error: any) {
-            console.error('Error making draft pick:', {
-                error,
-                message: error?.message,
-                name: error?.name,
-                stack: error?.stack,
-                details: error?.details
-            });
-            alert(`Failed to make draft pick: ${error?.message || 'Unknown error'}. Please try again.`);
-        }
+        });
     };
-    
-    // Function to toggle auto-pick preference
-    const toggleAutoPick = async () => {
+
+    const handleStartDraft = () => {
+        startTransition(async () => {
+            const result = await startDraft(draftSettings.id);
+            if (!result.success) {
+                alert(result.error || 'Failed to start draft');
+            }
+        });
+    };
+
+    const handleTogglePause = () => {
+        startTransition(async () => {
+            const result = await togglePause(draftSettings.id);
+            if (!result.success) {
+                alert(result.error || 'Failed to toggle pause');
+            }
+        });
+    };
+
+    const handleToggleAutoPick = () => {
         if (!currentTeam || currentTeam.id === 'commissioner') return;
-        
-        const newValue = !autoPickEnabled;
-        
-        try {
-            const { error } = await supabase
-                .from('teams')
-                .update({ auto_pick_preference: newValue })
-                .eq('id', currentTeam.id);
-                
-            if (error) throw error;
-            
-            // Update local state after successful DB update
-            setAutoPickEnabled(newValue);
-            
-            // Show confirmation to user
-            alert(`Auto-pick has been ${newValue ? 'enabled' : 'disabled'}.`);
-        } catch (error) {
-            console.error('Error updating auto-pick preference:', error);
-            alert('Failed to update auto-pick preference. Please try again.');
-        }
+
+        startTransition(async () => {
+            const result = await toggleAutoPick(currentTeam.id);
+            if (!result.success) {
+                alert(result.error || 'Failed to update auto-pick preference');
+            } else {
+                setAutoPickEnabled(result.data.autoPickEnabled);
+            }
+        });
     };
-    
-    // Function to start the draft (commissioner only)
-    const startDraft = async () => {
-        if (!isCommissioner) return;
-        
-        try {
-            const { error } = await supabase
-                .from('draft_settings')
-                .update({
-                    draft_status: 'in_progress',
-                    updated_at: new Date().toISOString()
-                })
-                .eq('id', draftSettings.id);
-                
-            if (error) throw error;
-        } catch (error) {
-            console.error('Error starting draft:', error);
-            alert('Failed to start draft. Please try again.');
-        }
-    };
-    
-    // Function to toggle draft pause state (commissioner only)
-    const toggleDraftPause = async () => {
-        if (!isCommissioner) return;
-        
-        try {
-            const newPausedState = !isPaused;
-            
-            const { error } = await supabase
-                .from('draft_settings')
-                .update({
-                    is_paused: newPausedState,
-                    updated_at: new Date().toISOString()
-                })
-                .eq('id', draftSettings.id);
-                
-            if (error) throw error;
-            
-            // Update local state immediately for better UX
-            setIsPaused(newPausedState);
-        } catch (error) {
-            console.error('Error toggling draft pause state:', error);
-            alert(`Failed to ${isPaused ? 'resume' : 'pause'} draft. Please try again.`);
+
+    const handleTimerExpired = async () => {
+        // Client-side fallback for auto-pick when timer expires
+        if (!isMyTurn || !autoPickEnabled) return;
+        if (!currentPickTeam) return;
+
+        const result = await triggerAutoPick(draftSettings.id, currentPickTeam.id);
+        if (!result.success) {
+            console.error('Client-side auto-pick fallback failed:', result.error);
         }
     };
 
@@ -427,13 +260,13 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
             setSearchResults(availablePlayers);
             return;
         }
-        
-        const filtered = availablePlayers.filter(player => 
+
+        const filtered = availablePlayers.filter(player =>
             player.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
             player.position.toLowerCase().includes(searchTerm.toLowerCase()) ||
             player.team_name.toLowerCase().includes(searchTerm.toLowerCase())
         );
-        
+
         setSearchResults(filtered);
     };
 
@@ -441,7 +274,7 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
     const isDraftActive = draftState.draft_status === 'in_progress';
     const isDraftCompleted = draftState.draft_status === 'completed';
     const isMyTurn = currentPickTeam?.id === currentTeam.id && isDraftActive;
-    
+
     return (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             {/* Left column - Draft Queue & History */}
@@ -450,13 +283,13 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                     <h2 className="text-xl font-bold mb-4 text-primary-text">Your Draft Queue</h2>
                     <DraftQueue teamId={currentTeam.id} draftId={draftSettings.id} />
                 </div>
-                
+
                 <div className="bg-surface rounded-xl p-4 shadow-lg">
                     <h2 className="text-xl font-bold mb-4 text-primary-text">Draft History</h2>
                     <DraftHistory draftPicks={draftPicks} />
                 </div>
             </div>
-            
+
             {/* Middle column - Draft Board */}
             <div className="lg:col-span-2 space-y-6">
                 <div className="bg-surface rounded-xl p-4 shadow-lg">
@@ -467,28 +300,30 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                                 <span className="ml-2 text-yellow-500 text-sm font-normal">(Paused)</span>
                             )}
                         </h2>
-                        
+
                         <div className="flex space-x-2">
                             {isCommissioner && !isDraftActive && !isDraftCompleted && (
                                 <button
-                                    onClick={startDraft}
-                                    className="px-4 py-2 bg-liquid-lava text-snow rounded-lg hover:opacity-80 transition-opacity"
+                                    onClick={handleStartDraft}
+                                    disabled={isPending}
+                                    className="px-4 py-2 bg-liquid-lava text-snow rounded-lg hover:opacity-80 transition-opacity disabled:opacity-50"
                                 >
-                                    Start Draft
+                                    {isPending ? 'Starting...' : 'Start Draft'}
                                 </button>
                             )}
-                            
+
                             {isCommissioner && isDraftActive && !isDraftCompleted && (
                                 <button
-                                    onClick={toggleDraftPause}
-                                    className={`px-4 py-2 ${isPaused ? 'bg-green-600' : 'bg-yellow-600'} text-snow rounded-lg hover:opacity-80 transition-opacity`}
+                                    onClick={handleTogglePause}
+                                    disabled={isPending}
+                                    className={`px-4 py-2 ${isPaused ? 'bg-green-600' : 'bg-yellow-600'} text-snow rounded-lg hover:opacity-80 transition-opacity disabled:opacity-50`}
                                 >
                                     {isPaused ? 'Resume Draft' : 'Pause Draft'}
                                 </button>
                             )}
                         </div>
                     </div>
-                    
+
                     {isDraftActive && (
                         <div className="mb-6 p-4 bg-gluon-grey rounded-lg">
                             <div className="flex flex-col sm:flex-row justify-between items-center">
@@ -502,45 +337,25 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                                         {currentPickTeam?.profiles?.full_name && ` (${currentPickTeam.profiles.full_name})`}
                                     </p>
                                 </div>
-                                
+
                                 <div className="mt-4 sm:mt-0">
                                     <div className="flex flex-col items-end">
-                                        <DraftTimer 
-                                            timePerPick={draftState.time_per_pick} 
+                                        <DraftTimer
+                                            timePerPick={draftState.time_per_pick}
+                                            timerStartedAt={draftState.timer_started_at}
                                             isMyTurn={isMyTurn}
                                             isPaused={isPaused}
-                                            onTimerExpired={async () => {
-                                                if (isMyTurn && autoPickEnabled) {
-                                                    // Call our auto-pick API
-                                                    try {
-                                                        const response = await fetch('/api/draft/auto-pick', {
-                                                            method: 'POST',
-                                                            headers: {
-                                                                'Content-Type': 'application/json',
-                                                            },
-                                                            body: JSON.stringify({
-                                                                draftId: draftSettings.id,
-                                                                teamId: currentTeam.id
-                                                            })
-                                                        });
-                                                        
-                                                        if (!response.ok) {
-                                                            console.error('Auto-pick failed', await response.json());
-                                                        }
-                                                    } catch (error) {
-                                                        console.error('Error triggering auto-pick:', error);
-                                                    }
-                                                }
-                                            }}
+                                            onTimerExpired={handleTimerExpired}
                                         />
-                                        
+
                                         {isMyTurn && (
                                             <div className="flex items-center mt-2">
                                                 <input
                                                     type="checkbox"
                                                     id="auto-pick"
                                                     checked={autoPickEnabled}
-                                                    onChange={toggleAutoPick}
+                                                    onChange={handleToggleAutoPick}
+                                                    disabled={isPending}
                                                     className="h-4 w-4 text-liquid-lava rounded focus:ring-liquid-lava mr-2"
                                                 />
                                                 <label htmlFor="auto-pick" className="text-xs text-secondary-text">
@@ -551,16 +366,20 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                                     </div>
                                 </div>
                             </div>
-                            
+
                             {isMyTurn && (
                                 <div className="mt-4 pt-4 border-t border-slate-grey">
                                     <p className="text-primary-text font-bold text-lg mb-2">It&apos;s Your Turn to Draft!</p>
-                                    
+
+                                    {pickError && (
+                                        <p className="text-red-500 text-sm mb-2">{pickError}</p>
+                                    )}
+
                                     {selectedPlayer ? (
                                         <div className="flex flex-col sm:flex-row items-center justify-between p-3 bg-surface rounded-lg">
                                             <div className="flex items-center mb-3 sm:mb-0">
-                                                <Image 
-                                                    src={selectedPlayer.pic_url || '/default-player.png'} 
+                                                <Image
+                                                    src={selectedPlayer.pic_url || '/default-player.png'}
                                                     alt={selectedPlayer.name}
                                                     className="w-12 h-12 rounded-full object-cover mr-3"
                                                     width={48}
@@ -573,7 +392,7 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                                                     </p>
                                                 </div>
                                             </div>
-                                            
+
                                             <div className="space-x-2">
                                                 <button
                                                     onClick={() => setSelectedPlayer(null)}
@@ -582,33 +401,11 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                                                     Cancel
                                                 </button>
                                                 <button
-                                                    onClick={() => {
-                                                        console.log('Confirm Pick clicked', { 
-                                                            selectedPlayerId: selectedPlayer?.id,
-                                                            selectedPlayerType: typeof selectedPlayer?.id,
-                                                            selectedPlayer
-                                                        });
-                                                        if (!selectedPlayer) {
-                                                            alert('No player selected');
-                                                            return;
-                                                        }
-                                                        
-                                                        // Extract player ID in a safe way - ensure it's a simple string
-                                                        const playerId = String(selectedPlayer.id);
-                                                        
-                                                        // Final validation check
-                                                        if (!playerId || playerId === 'undefined' || playerId === '[object Object]') {
-                                                            console.error('Invalid player ID:', playerId);
-                                                            alert('Invalid player data. Please try selecting a different player.');
-                                                            return;
-                                                        }
-                                                        
-                                                        console.log('Using player ID:', playerId, 'type:', typeof playerId);
-                                                        makeDraftPick(playerId);
-                                                    }}
-                                                    className="px-3 py-1 bg-liquid-lava text-snow rounded"
+                                                    onClick={() => handleMakePick(String(selectedPlayer.id))}
+                                                    disabled={isPending}
+                                                    className="px-3 py-1 bg-liquid-lava text-snow rounded disabled:opacity-50"
                                                 >
-                                                    Confirm Pick
+                                                    {isPending ? 'Picking...' : 'Confirm Pick'}
                                                 </button>
                                             </div>
                                         </div>
@@ -621,13 +418,13 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                             )}
                         </div>
                     )}
-                    
+
                     {!isDraftActive && !isDraftCompleted && (
                         <div className="mb-6 p-4 bg-gluon-grey rounded-lg">
                             <p className="text-lg">
                                 The draft is scheduled to begin{' '}
-                                {draftState.draft_date 
-                                    ? `on ${new Date(draftState.draft_date).toLocaleString()}` 
+                                {draftState.draft_date
+                                    ? `on ${new Date(draftState.draft_date).toLocaleString()}`
                                     : 'soon'}
                             </p>
                             <p className="text-secondary-text mt-2">
@@ -635,82 +432,57 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                             </p>
                         </div>
                     )}
-                    
+
                     <div className="mb-4">
                         <h3 className="text-lg font-semibold mb-2">Teams</h3>
-                        <TeamPicker 
+                        <TeamPicker
                             teams={leagueTeams}
                             draftOrder={draftState.pick_order?.order || []}
                             currentPick={draftState.current_pick}
                         />
                     </div>
-                    
+
                     <div>
                         <h3 className="text-lg font-semibold mb-2">Available Players</h3>
-                        <PlayerSearch 
+                        <PlayerSearch
                             availablePlayers={availablePlayers}
                             searchResults={searchResults}
                             isLoading={isLoading}
                             onSearch={handleSearch}
                             onSelectPlayer={(player) => {
-                                console.log('Player selected:', player);
                                 if (player && typeof player === 'object') {
-                                    // Ensure we only store a clean player object with a string ID
-                                    const cleanPlayer = {
-                                        ...player,
-                                        id: typeof player.id === 'object' 
-                                            ? String((player.id as any).id || JSON.stringify(player.id)) 
-                                            : String(player.id)
-                                    };
-                                    console.log('Setting clean player with ID:', cleanPlayer.id, 'type:', typeof cleanPlayer.id);
-                                    setSelectedPlayer(cleanPlayer);
-                                } else {
-                                    console.error('Invalid player object received:', player);
+                                    setSelectedPlayer({ ...player, id: String(player.id) });
                                 }
                             }}
                             onAddToQueue={async (player) => {
                                 try {
-                                    // Check if player is already in queue
                                     const { data: currentQueue, error: queueError } = await supabase
                                         .from('draft_queue')
                                         .select('id, player_id, priority')
                                         .eq('team_id', currentTeam.id)
                                         .order('priority', { ascending: true });
-                                        
+
                                     if (queueError) throw queueError;
-                                    
-                                    // Check if player is already in queue
+
                                     if (currentQueue?.some(item => item.player_id === player.id)) {
                                         alert('This player is already in your queue.');
                                         return;
                                     }
-                                    
-                                    // Calculate next priority
-                                    const nextPriority = currentQueue?.length 
-                                        ? Math.max(...currentQueue.map(item => item.priority)) + 1 
+
+                                    const nextPriority = currentQueue?.length
+                                        ? Math.max(...currentQueue.map(item => item.priority)) + 1
                                         : 1;
-                                    
-                                    // Use .select() to get the result and help with debugging
-                                    const { data, error, status } = await supabase
+
+                                    const { error } = await supabase
                                         .from('draft_queue')
                                         .insert({
                                             team_id: currentTeam.id,
                                             player_id: player.id,
                                             priority: nextPriority
-                                        })
-                                        .select();
-                                        
-                                    if (error) {
-                                        console.error('Supabase error adding to queue:', { 
-                                            error, 
-                                            message: error.message,
-                                            details: error.details,
-                                            code: error.code
                                         });
-                                        throw error;
-                                    }
-                                    
-                                    console.log('Player added to queue successfully:', data);
+
+                                    if (error) throw error;
+
                                     alert('Player added to your queue!');
                                 } catch (error: any) {
                                     console.error('Error adding player to queue:', error);

--- a/app/draft/[id]/draft-timer.tsx
+++ b/app/draft/[id]/draft-timer.tsx
@@ -1,66 +1,60 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import { createClient } from '@/app/utils/supabase/client';
 
 interface DraftTimerProps {
     timePerPick: number;
+    timerStartedAt: string | null;
     isMyTurn: boolean;
     isPaused?: boolean;
     onTimerExpired?: () => void;
 }
 
-export default function DraftTimer({ timePerPick, isMyTurn, isPaused = false, onTimerExpired }: DraftTimerProps) {
+export default function DraftTimer({ timePerPick, timerStartedAt, isMyTurn, isPaused = false, onTimerExpired }: DraftTimerProps) {
     const [timeLeft, setTimeLeft] = useState(timePerPick);
-    const supabase = createClient();
-    
-    // Auto-pick function (when timer expires)
-    const handleTimerExpired = useCallback(async () => {
-        // If we have an external handler, call it
-        if (onTimerExpired) {
-            onTimerExpired();
-            return;
-        }
-        
-        // Otherwise, we're looking at a basic auto-pick scenario
-        // The server should handle auto-picks through database triggers
-        // But we can also implement client-side logic here if needed
-        console.log('Timer expired - auto-pick will be triggered by server');
-        
-        // You could also implement direct auto-pick logic here if needed
-        // For now we'll let the server handle it via the database trigger
-    }, [onTimerExpired]);
-    
+    const [hasExpired, setHasExpired] = useState(false);
+
+    const computeTimeLeft = useCallback(() => {
+        if (!timerStartedAt || isPaused) return timePerPick;
+        const elapsed = (Date.now() - new Date(timerStartedAt).getTime()) / 1000;
+        return Math.max(0, Math.ceil(timePerPick - elapsed));
+    }, [timerStartedAt, timePerPick, isPaused]);
+
+    // Reset expiry flag when timer restarts (new pick)
     useEffect(() => {
-        // Reset timer when it's a new turn
-        setTimeLeft(timePerPick);
-        
-        // Don't start the timer if draft is paused
-        if (isPaused) {
+        setHasExpired(false);
+        setTimeLeft(computeTimeLeft());
+    }, [timerStartedAt, computeTimeLeft]);
+
+    useEffect(() => {
+        if (isPaused || !timerStartedAt) {
+            setTimeLeft(timePerPick);
             return;
         }
-        
-        // Start countdown
-        const timer = setInterval(() => {
-            setTimeLeft(prev => {
-                if (prev <= 1) {
-                    clearInterval(timer);
-                    // Call auto-pick function when timer reaches zero
-                    handleTimerExpired();
-                    return 0;
+
+        const tick = () => {
+            const remaining = computeTimeLeft();
+            setTimeLeft(remaining);
+
+            if (remaining <= 0 && !hasExpired) {
+                setHasExpired(true);
+                if (onTimerExpired) {
+                    onTimerExpired();
                 }
-                return prev - 1;
-            });
-        }, 1000);
-        
-        return () => {
-            clearInterval(timer);
+            }
         };
-    }, [timePerPick, isMyTurn, isPaused, handleTimerExpired]);
-    
+
+        // Compute immediately
+        tick();
+
+        const timer = setInterval(tick, 1000);
+
+        return () => clearInterval(timer);
+    }, [timerStartedAt, timePerPick, isPaused, onTimerExpired, computeTimeLeft, hasExpired]);
+
     // Calculate percentage for visual timer
     const percentage = (timeLeft / timePerPick) * 100;
-    
+
     // Determine color based on time left
     let timerColor = 'bg-green-500';
     if (timeLeft < timePerPick * 0.3) {
@@ -68,7 +62,7 @@ export default function DraftTimer({ timePerPick, isMyTurn, isPaused = false, on
     } else if (timeLeft < timePerPick * 0.6) {
         timerColor = 'bg-yellow-500';
     }
-    
+
     return (
         <div className="w-32">
             <div className="flex justify-between mb-1">
@@ -76,15 +70,15 @@ export default function DraftTimer({ timePerPick, isMyTurn, isPaused = false, on
                     {isPaused ? "PAUSED" : "Time Left:"}
                 </span>
                 <span className={`text-sm font-bold ${
-                    isPaused ? 'text-yellow-500' : 
+                    isPaused ? 'text-yellow-500' :
                     timeLeft < timePerPick * 0.3 ? 'text-red-500' : 'text-primary-text'
                 }`}>
-                    {isPaused ? "⏸️" : `${timeLeft}s`}
+                    {isPaused ? "\u23F8\uFE0F" : `${timeLeft}s`}
                 </span>
             </div>
-            
+
             <div className="w-full bg-slate-grey rounded-full h-2.5">
-                <div 
+                <div
                     className={`h-2.5 rounded-full ${isPaused ? 'bg-yellow-500' : timerColor} transition-all duration-1000 ease-linear`}
                     style={{ width: isPaused ? '100%' : `${percentage}%` }}
                 ></div>

--- a/app/draft/[id]/player-search.tsx
+++ b/app/draft/[id]/player-search.tsx
@@ -12,6 +12,8 @@ interface PlayerSearchProps {
     onSelectPlayer: (player: any) => void;
     onAddToQueue: (player: any) => Promise<void>; // Function to add player to queue
     isMyTurn: boolean;
+    isCommissioner?: boolean; // Commissioner can draft for any team
+    isDraftActive?: boolean; // Whether draft is in progress
     selectedPlayer: any | null;
     leagueType?: string; // 'NFL', 'NBA', 'NCAAM', etc.
 }
@@ -24,6 +26,8 @@ export default function PlayerSearch({
     onSelectPlayer,
     onAddToQueue,
     isMyTurn,
+    isCommissioner = false,
+    isDraftActive = false,
     selectedPlayer,
     leagueType = 'NFL' // Default to NFL if not provided
 }: PlayerSearchProps) {
@@ -173,7 +177,7 @@ export default function PlayerSearch({
                                                     Queue
                                                 </button>
                                                 
-                                                {isMyTurn && (
+                                                {(isMyTurn || (isCommissioner && isDraftActive)) && (
                                                     <button
                                                         className="px-2 py-1 bg-liquid-lava text-snow text-xs rounded"
                                                         onClick={() => {

--- a/app/utils/supabase/debug.ts
+++ b/app/utils/supabase/debug.ts
@@ -39,3 +39,4 @@ if (typeof window !== 'undefined') {
 }
 
 
+

--- a/documentation/TODO-rls-policies.md
+++ b/documentation/TODO-rls-policies.md
@@ -1,0 +1,15 @@
+# TODO: RLS Policy Changes for Draft
+
+These RLS policy changes should be applied **after** verifying the draft works end-to-end with the new RPC-based flow.
+
+## 1. Block direct `draft_picks` INSERT/UPDATE
+
+All picks now go through the `make_draft_pick` RPC (which runs as `SECURITY DEFINER`). Remove or restrict the existing RLS policies that allow clients to directly INSERT or UPDATE `draft_picks`.
+
+## 2. Restrict `draft_settings` UPDATE to commissioner
+
+Only the league commissioner should be able to UPDATE `draft_settings` (start draft, pause/resume, change timer). Add a policy that checks the authenticated user is the commissioner of the league that owns the draft.
+
+## 3. Restrict `draft_queue` to own team
+
+Ensure `draft_queue` INSERT/UPDATE/DELETE policies only allow users to modify queue entries for their own team.

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -123,6 +123,7 @@ export type Database = {
           league_id: string
           pick_order: Json | null
           time_per_pick: number
+          timer_started_at: string | null
           updated_at: string | null
         }
         Insert: {
@@ -138,6 +139,7 @@ export type Database = {
           league_id: string
           pick_order?: Json | null
           time_per_pick?: number
+          timer_started_at?: string | null
           updated_at?: string | null
         }
         Update: {
@@ -153,6 +155,7 @@ export type Database = {
           league_id?: string
           pick_order?: Json | null
           time_per_pick?: number
+          timer_started_at?: string | null
           updated_at?: string | null
         }
         Relationships: [
@@ -691,6 +694,19 @@ export type Database = {
           team_id: string
         }
         Returns: string
+      }
+      make_draft_pick: {
+        Args: {
+          p_draft_id: string
+          p_team_id: string
+          p_player_id: string
+          p_is_auto_pick?: boolean
+        }
+        Returns: Json
+      }
+      auto_pick_expired_drafts: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
       }
       insert_default_scoring_rules: {
         Args: Record<PropertyKey, never>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1029,6 +1029,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.48.1.tgz",
       "integrity": "sha512-VMD+CYk/KxfwGbI4fqwSUVA7CLr1izXpqfFerhnYPSi6LEKD8GoR4kuO5Cc8a+N43LnfSQwLJu4kVm2e4etEmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.67.3",
         "@supabase/functions-js": "2.4.4",
@@ -1114,6 +1115,7 @@
       "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1179,6 +1181,7 @@
       "integrity": "sha512-MFDaO9CYiard9j9VepMNa9MTcqVvSny2N4hkY6roquzj8pdCBRENhErrteaQuu7Yjn1ppk0v1/ZF9CG3KIlrTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.24.0",
         "@typescript-eslint/types": "8.24.0",
@@ -1385,6 +1388,7 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1827,6 +1831,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2550,6 +2555,7 @@
       "integrity": "sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2723,6 +2729,7 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -4048,6 +4055,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4865,6 +4873,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -5068,6 +5077,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5077,6 +5087,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
       "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.25.0"
       },
@@ -5150,7 +5161,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -6081,6 +6093,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6243,6 +6256,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/supabase/migrations/20260314_draft_server_actions.sql
+++ b/supabase/migrations/20260314_draft_server_actions.sql
@@ -1,0 +1,222 @@
+-- Migration: Draft Server Actions + Postgres RPC
+-- Adds timer_started_at column and make_draft_pick atomic RPC function
+
+-- Step 1: Add timer_started_at column to draft_settings
+ALTER TABLE draft_settings
+ADD COLUMN IF NOT EXISTS timer_started_at TIMESTAMPTZ;
+
+-- Step 2: Create the atomic make_draft_pick function
+CREATE OR REPLACE FUNCTION make_draft_pick(
+    p_draft_id UUID,
+    p_team_id UUID,
+    p_player_id TEXT,
+    p_is_auto_pick BOOLEAN DEFAULT FALSE
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_draft RECORD;
+    v_pick_order UUID[];
+    v_total_teams INT;
+    v_current_index INT;
+    v_expected_team_id UUID;
+    v_total_picks INT;
+    v_max_picks INT;
+    v_new_pick_number INT;
+    v_new_round INT;
+    v_new_current_pick INT;
+    v_pick_id UUID;
+    v_is_snake BOOLEAN;
+    v_next_index INT;
+BEGIN
+    -- Lock the draft_settings row to prevent concurrent picks
+    SELECT *
+    INTO v_draft
+    FROM draft_settings
+    WHERE id = p_draft_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Draft not found');
+    END IF;
+
+    -- Verify draft is in progress and not paused
+    IF v_draft.draft_status != 'in_progress' THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Draft is not in progress');
+    END IF;
+
+    IF v_draft.is_paused THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Draft is paused');
+    END IF;
+
+    -- Extract pick order array from JSONB
+    SELECT ARRAY(
+        SELECT (jsonb_array_elements_text(v_draft.pick_order->'order'))::UUID
+    ) INTO v_pick_order;
+
+    v_total_teams := array_length(v_pick_order, 1);
+
+    IF v_total_teams IS NULL OR v_total_teams = 0 THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Invalid pick order');
+    END IF;
+
+    -- Determine if snake draft
+    v_is_snake := (v_draft.draft_type = 'snake');
+
+    -- Calculate which team should be picking
+    -- For snake drafts: odd rounds go forward, even rounds go backward
+    v_current_index := ((v_draft.current_pick - 1) % v_total_teams) + 1;
+
+    IF v_is_snake AND (v_draft.current_round % 2 = 0) THEN
+        -- Even rounds go in reverse order
+        v_expected_team_id := v_pick_order[v_total_teams - v_current_index + 1];
+    ELSE
+        v_expected_team_id := v_pick_order[v_current_index];
+    END IF;
+
+    -- Verify it's the correct team's turn
+    IF v_expected_team_id != p_team_id THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Not this team''s turn');
+    END IF;
+
+    -- Verify player hasn't already been drafted
+    IF EXISTS (
+        SELECT 1 FROM draft_picks
+        WHERE draft_id = p_draft_id AND player_id = p_player_id
+    ) THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Player already drafted');
+    END IF;
+
+    -- Verify player exists
+    IF NOT EXISTS (
+        SELECT 1 FROM players WHERE id = p_player_id
+    ) THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Player not found');
+    END IF;
+
+    -- Calculate pick number (overall pick number across all rounds)
+    v_new_pick_number := ((v_draft.current_round - 1) * v_total_teams) + v_draft.current_pick;
+
+    -- Insert the draft pick
+    INSERT INTO draft_picks (draft_id, team_id, player_id, pick_number, round_number, is_auto_pick)
+    VALUES (p_draft_id, p_team_id, p_player_id, v_new_pick_number, v_draft.current_round, p_is_auto_pick)
+    RETURNING id INTO v_pick_id;
+
+    -- Advance to next pick
+    v_new_current_pick := v_draft.current_pick + 1;
+    v_new_round := v_draft.current_round;
+
+    IF v_new_current_pick > v_total_teams THEN
+        -- Move to next round
+        v_new_current_pick := 1;
+        v_new_round := v_new_round + 1;
+    END IF;
+
+    -- Calculate max total picks based on number of rounds in draft
+    -- Use the total_rounds from draft settings, or default to a reasonable number
+    v_max_picks := v_total_teams * COALESCE(
+        (v_draft.pick_order->>'total_rounds')::INT,
+        15  -- default fallback
+    );
+
+    v_total_picks := (SELECT COUNT(*) FROM draft_picks WHERE draft_id = p_draft_id);
+
+    -- Check if draft is complete
+    IF v_total_picks >= v_max_picks THEN
+        UPDATE draft_settings
+        SET draft_status = 'completed',
+            current_pick = v_new_current_pick,
+            current_round = v_new_round,
+            timer_started_at = NULL,
+            updated_at = NOW()
+        WHERE id = p_draft_id;
+
+        RETURN jsonb_build_object(
+            'success', true,
+            'pick_id', v_pick_id,
+            'draft_completed', true
+        );
+    END IF;
+
+    -- Update draft settings for next pick
+    UPDATE draft_settings
+    SET current_pick = v_new_current_pick,
+        current_round = v_new_round,
+        timer_started_at = NOW(),
+        updated_at = NOW()
+    WHERE id = p_draft_id;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'pick_id', v_pick_id,
+        'draft_completed', false,
+        'next_pick', v_new_current_pick,
+        'next_round', v_new_round
+    );
+END;
+$$;
+
+-- Step 3: Create auto_pick_expired_drafts function for server-side auto-pick
+CREATE OR REPLACE FUNCTION auto_pick_expired_drafts()
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_draft RECORD;
+    v_pick_order UUID[];
+    v_total_teams INT;
+    v_current_index INT;
+    v_current_team_id UUID;
+    v_selected_player_id TEXT;
+    v_is_snake BOOLEAN;
+BEGIN
+    -- Find all drafts where the timer has expired
+    FOR v_draft IN
+        SELECT *
+        FROM draft_settings
+        WHERE draft_status = 'in_progress'
+          AND is_paused = false
+          AND timer_started_at IS NOT NULL
+          AND NOW() - timer_started_at > (time_per_pick * INTERVAL '1 second')
+        FOR UPDATE SKIP LOCKED
+    LOOP
+        -- Extract pick order
+        SELECT ARRAY(
+            SELECT (jsonb_array_elements_text(v_draft.pick_order->'order'))::UUID
+        ) INTO v_pick_order;
+
+        v_total_teams := array_length(v_pick_order, 1);
+        IF v_total_teams IS NULL OR v_total_teams = 0 THEN
+            CONTINUE;
+        END IF;
+
+        v_is_snake := (v_draft.draft_type = 'snake');
+        v_current_index := ((v_draft.current_pick - 1) % v_total_teams) + 1;
+
+        IF v_is_snake AND (v_draft.current_round % 2 = 0) THEN
+            v_current_team_id := v_pick_order[v_total_teams - v_current_index + 1];
+        ELSE
+            v_current_team_id := v_pick_order[v_current_index];
+        END IF;
+
+        -- Use existing auto_pick_player function to select best player
+        SELECT auto_pick_player(v_draft.id, v_current_team_id) INTO v_selected_player_id;
+
+        IF v_selected_player_id IS NOT NULL THEN
+            -- Use make_draft_pick to atomically make the pick
+            PERFORM make_draft_pick(v_draft.id, v_current_team_id, v_selected_player_id, true);
+        END IF;
+    END LOOP;
+END;
+$$;
+
+-- Step 4: Grant execute permissions
+GRANT EXECUTE ON FUNCTION make_draft_pick(UUID, UUID, TEXT, BOOLEAN) TO authenticated;
+GRANT EXECUTE ON FUNCTION auto_pick_expired_drafts() TO service_role;
+
+-- Note: pg_cron setup (run in Supabase SQL editor if pg_cron is available):
+-- SELECT cron.schedule('draft-auto-pick', '5 seconds', 'SELECT auto_pick_expired_drafts()');
+-- If pg_cron is not available, use Vercel CRON or the auto-pick API route as fallback.


### PR DESCRIPTION
## Summary

- **Server Actions + RPC**: All draft mutations (`make_draft_pick`, pause/resume, start draft) now go through Server Actions calling a Supabase RPC, replacing direct client-side table writes
- **Server-authoritative timer**: Timer is driven by `timer_started_at` column on `draft_settings`, broadcast via Realtime — no more client-side timer drift
- **Commissioner multi-team picks**: Commissioner can draft on behalf of any team during that team's turn, with confirmation UI
- **Auto-pick simplification**: Auto-pick route now calls the same `make_draft_pick` RPC
- **RLS TODO**: Deferred RLS policy tightening tracked in `documentation/TODO-rls-policies.md`

## Files changed

| File | What changed |
|---|---|
| `app/draft/[id]/actions.ts` | New — all mutations are Server Actions calling `make_draft_pick` RPC |
| `app/draft/[id]/draft-room.tsx` | Removed client-side mutations, uses `useTransition`, commissioner pick flow |
| `app/draft/[id]/draft-timer.tsx` | Server-authoritative timer from `timerStartedAt` prop |
| `app/api/draft/auto-pick/route.ts` | Simplified to call `make_draft_pick` RPC |
| `lib/database.types.ts` | Added `timer_started_at`, `make_draft_pick`, `auto_pick_expired_drafts` types |
| `supabase/migrations/20260314_draft_server_actions.sql` | RPC function + timer column migration |
| `documentation/TODO-rls-policies.md` | Deferred RLS policy changes |

## Test plan

- [x] `npm run build` + `npm run lint` pass (verified)
- [x] Start draft as commissioner — timer counts down from `timer_started_at`
- [x] Make a pick — turn advances, timer resets, other clients see update via Realtime
- [x] Pause/resume draft — timer stops and restarts
- [ ] Toggle auto-pick — preference persists
- [ ] Let timer expire with auto-pick enabled — auto-pick fires
- [x] Commissioner can pick for another team during their turn

🤖 Generated with [Claude Code](https://claude.ai/code)