### PR TITLE
feat: rankings edit mode and reset-to-default

### DIFF
--- a/app/rankings/ncaa/actions.ts
+++ b/app/rankings/ncaa/actions.ts
@@ -36,6 +36,48 @@ export async function savePlayerRankings(
   return { success: true };
 }
 
+export async function deletePlayerRankings(): Promise<ActionResult> {
+  const supabase = await createClient();
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return { success: false, error: 'Not authenticated' };
+  }
+
+  const { error } = await supabase
+    .from('user_ncaa_rankings')
+    .delete()
+    .eq('user_id', user.id)
+    .eq('season_year', 2026);
+
+  if (error) {
+    return { success: false, error: error.message };
+  }
+
+  return { success: true };
+}
+
+export async function deleteExpectedGames(): Promise<ActionResult> {
+  const supabase = await createClient();
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return { success: false, error: 'Not authenticated' };
+  }
+
+  const { error } = await supabase
+    .from('user_ncaa_team_settings')
+    .delete()
+    .eq('user_id', user.id)
+    .eq('season_year', 2026);
+
+  if (error) {
+    return { success: false, error: error.message };
+  }
+
+  return { success: true };
+}
+
 export async function saveExpectedGames(
   settings: { team_name: string; expected_games: number }[]
 ): Promise<ActionResult> {

--- a/app/rankings/ncaa/player-ranking-card.tsx
+++ b/app/rankings/ncaa/player-ranking-card.tsx
@@ -11,6 +11,7 @@ interface PlayerRankingCardProps {
   expectedGames: number;
   provided: DraggableProvided;
   isDragging: boolean;
+  isEditing: boolean;
 }
 
 export default function PlayerRankingCard({
@@ -19,6 +20,7 @@ export default function PlayerRankingCard({
   expectedGames,
   provided,
   isDragging,
+  isEditing,
 }: PlayerRankingCardProps) {
   const borderColor = getPositionBorderColor(player.position, 'NCAAM');
   const posTextColor = getPositionTextColor(player.position, 'NCAAM');
@@ -39,16 +41,20 @@ export default function PlayerRankingCard({
       }}
     >
       {/* Drag handle */}
-      <div
-        {...provided.dragHandleProps}
-        className="flex-shrink-0 mr-2 sm:mr-3 cursor-grab active:cursor-grabbing"
-      >
-        <div className="flex flex-col gap-0.5">
-          <div className="w-4 h-0.5 bg-muted-foreground/40 rounded" />
-          <div className="w-4 h-0.5 bg-muted-foreground/40 rounded" />
-          <div className="w-4 h-0.5 bg-muted-foreground/40 rounded" />
+      {isEditing ? (
+        <div
+          {...provided.dragHandleProps}
+          className="flex-shrink-0 mr-2 sm:mr-3 cursor-grab active:cursor-grabbing"
+        >
+          <div className="flex flex-col gap-0.5">
+            <div className="w-4 h-0.5 bg-muted-foreground/40 rounded" />
+            <div className="w-4 h-0.5 bg-muted-foreground/40 rounded" />
+            <div className="w-4 h-0.5 bg-muted-foreground/40 rounded" />
+          </div>
         </div>
-      </div>
+      ) : (
+        <div {...provided.dragHandleProps} className="hidden" />
+      )}
 
       {/* Rank number */}
       <div className="flex-shrink-0 mr-2 sm:mr-3">

--- a/app/rankings/ncaa/player-rankings-list.tsx
+++ b/app/rankings/ncaa/player-rankings-list.tsx
@@ -9,6 +9,7 @@ interface PlayerRankingsListProps {
   onReorder: (newOrder: PlayerWithStats[]) => void;
   expectedGames: Record<string, number>;
   rankMap?: Map<string, number>;
+  isEditing: boolean;
 }
 
 export default function PlayerRankingsList({
@@ -16,6 +17,7 @@ export default function PlayerRankingsList({
   onReorder,
   expectedGames,
   rankMap,
+  isEditing,
 }: PlayerRankingsListProps) {
   const handleDragEnd = (result: DropResult) => {
     if (!result.destination) return;
@@ -37,7 +39,7 @@ export default function PlayerRankingsList({
 
   return (
     <DragDropContext onDragEnd={handleDragEnd}>
-      <Droppable droppableId="playerRankings">
+      <Droppable droppableId="playerRankings" isDropDisabled={!isEditing}>
         {(provided) => (
           <div
             {...provided.droppableProps}
@@ -45,7 +47,7 @@ export default function PlayerRankingsList({
             className="space-y-1"
           >
             {players.map((player, index) => (
-              <Draggable key={player.id} draggableId={player.id} index={index}>
+              <Draggable key={player.id} draggableId={player.id} index={index} isDragDisabled={!isEditing}>
                 {(provided, snapshot) => (
                   <PlayerRankingCard
                     player={player}
@@ -53,6 +55,7 @@ export default function PlayerRankingsList({
                     expectedGames={expectedGames[player.team_name] || 1}
                     provided={provided}
                     isDragging={snapshot.isDragging}
+                    isEditing={isEditing}
                   />
                 )}
               </Draggable>

--- a/app/rankings/ncaa/rankings-page.tsx
+++ b/app/rankings/ncaa/rankings-page.tsx
@@ -6,8 +6,8 @@ import RankingsFilters from './rankings-filters';
 import PlayerRankingsList from './player-rankings-list';
 import ExpectedGamesSection from './expected-games-section';
 import TeamsTable from './teams-table';
-import { savePlayerRankings, saveExpectedGames } from './actions';
-import { computeProjectedTotal } from './utils';
+import { savePlayerRankings, saveExpectedGames, deletePlayerRankings, deleteExpectedGames } from './actions';
+import { computeProjectedTotal, getDefaultExpectedGames } from './utils';
 import type { PlayerWithStats, NcaaTeamInfo, UserRanking, UserTeamSetting } from './utils';
 
 type SortBy = 'projection' | 'expectedGames' | 'custom';
@@ -60,7 +60,13 @@ export default function RankingsPage({
   }, [orderedPlayers]);
 
   const [hasUnsavedRankings, setHasUnsavedRankings] = useState(false);
+  const [hasCustomRankings, setHasCustomRankings] = useState(userRankings.length > 0);
+  const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+
+  // Snapshot of player order before editing, for cancel
+  const preEditOrderRef = useRef<PlayerWithStats[]>(orderedPlayers);
+  const preEditSortByRef = useRef<SortBy>(sortBy);
 
   // Debounce ref for expected games saving
   const gamesTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -184,8 +190,44 @@ export default function RankingsPage({
     }));
     await savePlayerRankings(rankings);
     setHasUnsavedRankings(false);
+    setHasCustomRankings(true);
+    setIsEditing(false);
     setIsSaving(false);
   }, [orderedPlayers]);
+
+  // Reset rankings to default projection order
+  const handleResetRankings = useCallback(async () => {
+    setOrderedPlayers((prev) =>
+      [...prev].sort((a, b) => b.projectedTotal - a.projectedTotal)
+    );
+    setSortBy('projection');
+    setHasUnsavedRankings(false);
+    setHasCustomRankings(false);
+    setIsEditing(false);
+    await deletePlayerRankings();
+  }, []);
+
+  // Build default expected games map from team seeds
+  const defaultExpectedGames = useMemo(() => {
+    const teamInfoMap = new Map(teamInfo.map((ti) => [ti.team_name, ti]));
+    const defaults: Record<string, number> = {};
+    for (const team of allTeams) {
+      defaults[team] = getDefaultExpectedGames(teamInfoMap.get(team)?.seed);
+    }
+    return defaults;
+  }, [teamInfo, allTeams]);
+
+  const hasCustomExpectedGames = useMemo(() => {
+    return allTeams.some((team) => expectedGames[team] !== defaultExpectedGames[team]);
+  }, [expectedGames, defaultExpectedGames, allTeams]);
+
+  // Reset expected games to seed-based defaults
+  const handleResetExpectedGames = useCallback(async () => {
+    setExpectedGames(defaultExpectedGames);
+    updateProjectedTotals(defaultExpectedGames);
+    if (gamesTimeoutRef.current) clearTimeout(gamesTimeoutRef.current);
+    await deleteExpectedGames();
+  }, [defaultExpectedGames, updateProjectedTotals]);
 
   // Cleanup timeouts
   useEffect(() => {
@@ -252,17 +294,49 @@ export default function RankingsPage({
                   );
                 })}
               </div>
-              <div className="flex items-center gap-3">
-                <span className="text-sm text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground mr-1">
                   {filteredPlayers.length} player{filteredPlayers.length !== 1 ? 's' : ''}
                 </span>
-                {hasUnsavedRankings && (
+                {(hasUnsavedRankings || hasCustomRankings) && (
                   <button
-                    onClick={handleSaveRankings}
-                    disabled={isSaving}
-                    className="px-3 py-1 rounded text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+                    onClick={handleResetRankings}
+                    className="px-3 py-1 rounded text-xs font-medium bg-muted text-muted-foreground hover:text-foreground transition-colors"
                   >
-                    {isSaving ? 'Saving...' : 'Save Rankings'}
+                    Reset to Default
+                  </button>
+                )}
+                {isEditing ? (
+                  <>
+                    <button
+                      onClick={() => {
+                        setOrderedPlayers(preEditOrderRef.current);
+                        setSortBy(preEditSortByRef.current);
+                        setHasUnsavedRankings(false);
+                        setIsEditing(false);
+                      }}
+                      className="px-3 py-1 rounded text-xs font-medium bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={handleSaveRankings}
+                      disabled={isSaving || !hasUnsavedRankings}
+                      className="px-3 py-1 rounded text-xs font-medium bg-muted text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+                    >
+                      {isSaving ? 'Saving...' : 'Save Changes'}
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    onClick={() => {
+                      preEditOrderRef.current = orderedPlayers;
+                      preEditSortByRef.current = sortBy;
+                      setIsEditing(true);
+                    }}
+                    className="px-3 py-1 rounded text-xs font-medium bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    Edit Rankings
                   </button>
                 )}
               </div>
@@ -273,15 +347,25 @@ export default function RankingsPage({
               onReorder={handleReorder}
               expectedGames={expectedGames}
               rankMap={rankMap}
+              isEditing={isEditing}
             />
           </TabsContent>
 
           <TabsContent value="teams">
+            {hasCustomExpectedGames && (
+              <div className="mb-3 flex justify-end">
+                <button
+                  onClick={handleResetExpectedGames}
+                  className="px-3 py-1 rounded text-xs font-medium bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Reset to Default
+                </button>
+              </div>
+            )}
             <TeamsTable
               teams={allTeams}
               teamInfo={teamInfo}
               expectedGames={expectedGames}
-              players={orderedPlayers}
               onExpectedGamesChange={handleExpectedGamesChange}
             />
           </TabsContent>

--- a/app/rankings/ncaa/teams-table.tsx
+++ b/app/rankings/ncaa/teams-table.tsx
@@ -9,13 +9,12 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import type { NcaaTeamInfo, PlayerWithStats } from './utils';
+import type { NcaaTeamInfo } from './utils';
 
 interface TeamsTableProps {
   teams: string[];
   teamInfo: NcaaTeamInfo[];
   expectedGames: Record<string, number>;
-  players: PlayerWithStats[];
   onExpectedGamesChange: (teamName: string, games: number) => void;
 }
 
@@ -23,7 +22,6 @@ export default function TeamsTable({
   teams,
   teamInfo,
   expectedGames,
-  players,
   onExpectedGamesChange,
 }: TeamsTableProps) {
   const teamInfoMap = new Map<string, NcaaTeamInfo>();
@@ -31,24 +29,15 @@ export default function TeamsTable({
     teamInfoMap.set(ti.team_name, ti);
   }
 
-  // Compute team-level aggregates
+  // Compute team-level data
   const teamData = teams.map((teamName) => {
     const info = teamInfoMap.get(teamName);
-    const teamPlayers = players.filter((p) => p.team_name === teamName);
-    const avgPpg =
-      teamPlayers.length > 0
-        ? Math.round(
-            (teamPlayers.reduce((sum, p) => sum + p.averages.ppg, 0) / teamPlayers.length) * 10
-          ) / 10
-        : 0;
 
     return {
       teamName,
       seed: info?.seed ?? null,
       region: info?.region ?? null,
       expectedGames: expectedGames[teamName] || 1,
-      playerCount: teamPlayers.length,
-      avgPpg,
     };
   });
 
@@ -66,21 +55,19 @@ export default function TeamsTable({
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Team</TableHead>
               <TableHead className="w-[60px] text-center">Seed</TableHead>
+              <TableHead>Team</TableHead>
               <TableHead className="hidden sm:table-cell">Region</TableHead>
               <TableHead className="w-[80px] text-center">Games</TableHead>
-              <TableHead className="w-[80px] text-center">Players</TableHead>
-              <TableHead className="w-[80px] text-right">Avg PPG</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {teamData.map((team) => (
               <TableRow key={team.teamName}>
-                <TableCell className="font-medium">{team.teamName}</TableCell>
                 <TableCell className="text-center">
                   {team.seed ? `#${team.seed}` : '-'}
                 </TableCell>
+                <TableCell className="font-medium">{team.teamName}</TableCell>
                 <TableCell className="hidden sm:table-cell">
                   {team.region || '-'}
                 </TableCell>
@@ -100,8 +87,6 @@ export default function TeamsTable({
                     className="bg-background border border-border rounded px-1 py-0.5 text-sm w-14 text-foreground"
                   />
                 </TableCell>
-                <TableCell className="text-center">{team.playerCount}</TableCell>
-                <TableCell className="text-right">{team.avgPpg}</TableCell>
               </TableRow>
             ))}
           </TableBody>


### PR DESCRIPTION
## Summary
- Add edit mode for player rankings — drag-and-drop now requires clicking "Edit Rankings" first, with Cancel to revert changes and Save Changes to persist
- Add "Reset to Default" button for player rankings that clears custom order and deletes saved rankings from DB
- Add "Reset to Default" button for expected games on the Teams tab that restores seed-based defaults
- Simplify teams table: remove Avg PPG and Player Count columns, reorder Seed before Team name
- Add `deletePlayerRankings` and `deleteExpectedGames` server actions

## Test plan
- [ ] Navigate to NCAA Rankings page
- [ ] Verify drag-and-drop is disabled by default (no drag handles visible)
- [ ] Click "Edit Rankings" — drag handles appear, Cancel and Save Changes buttons shown
- [ ] Drag to reorder, click Cancel — order reverts to pre-edit state
- [ ] Drag to reorder, click Save Changes — order persists, reload confirms
- [ ] Click "Reset to Default" on Players tab — rankings revert to projection order, reload confirms
- [ ] Switch to Teams tab, modify expected games for a team
- [ ] Verify "Reset to Default" button appears, click it — values revert to seed-based defaults
- [ ] Reload page to confirm expected games reset persisted

🤖 Generated with [Claude Code](https://claude.ai/code)