### PR TITLE
feat: integrate NCAA rankings into draft page

### DIFF
--- a/app/draft/[id]/draft-room.tsx
+++ b/app/draft/[id]/draft-room.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useTransition } from 'react';
+import { useEffect, useState, useMemo, useTransition } from 'react';
 import { createClient } from '@/app/utils/supabase/client';
 import DraftQueue from './draft-queue';
 import PlayerSearch from './player-search';
@@ -10,15 +10,21 @@ import DraftInfoPanel from './draft-info-panel';
 import { makePick, startDraft, togglePause, toggleAutoPick, triggerAutoPick } from './actions';
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { getDefaultExpectedGames, parsePlayerSummary, computeProjectedTotal } from '@/app/rankings/ncaa/utils';
+
+type PlayerSortBy = 'rank' | 'projection' | 'name';
 
 interface DraftRoomProps {
     draftSettings: any;
     currentTeam: any;
     isCommissioner: boolean;
     leagueTeams?: any[];
+    userRankings?: any[];
+    userTeamSettings?: any[];
+    ncaaTeamInfo?: any[];
 }
 
-export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, leagueTeams = [] }: DraftRoomProps) {
+export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, leagueTeams = [], userRankings = [], userTeamSettings = [], ncaaTeamInfo = [] }: DraftRoomProps) {
     const supabase = createClient();
 
     // Draft state
@@ -33,6 +39,63 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
     const [isPaused, setIsPaused] = useState<boolean>(draftSettings.is_paused || false);
     const [pickError, setPickError] = useState<string | null>(null);
     const [isPending, startTransition] = useTransition();
+    const [isQueueOpen, setIsQueueOpen] = useState(true);
+
+    const isNcaam = draftSettings.leagues.league === 'NCAAM';
+    const [playerSortBy, setPlayerSortBy] = useState<PlayerSortBy>(isNcaam ? 'rank' : 'name');
+
+    // Build NCAAM ranking/projection maps
+    const expectedGamesMap = useMemo(() => {
+        if (!isNcaam) return {};
+        const map: Record<string, number> = {};
+        for (const ti of ncaaTeamInfo) {
+            map[ti.team_name] = getDefaultExpectedGames(ti.seed);
+        }
+        for (const s of userTeamSettings) {
+            map[s.team_name] = s.expected_games;
+        }
+        return map;
+    }, [isNcaam, ncaaTeamInfo, userTeamSettings]);
+
+    const rankMap = useMemo(() => {
+        const m = new Map<string, number>();
+        for (const r of userRankings) {
+            m.set(r.player_id, r.rank_position);
+        }
+        return m;
+    }, [userRankings]);
+
+    // Enrich players with NCAAM rank/projection and sort
+    const enrichAndSort = (players: any[]): any[] => {
+        if (!isNcaam) return players;
+        return players.map(p => {
+            const { ppg } = parsePlayerSummary(p.summary);
+            const expGames = expectedGamesMap[p.team_name] || 1;
+            return {
+                ...p,
+                rank: rankMap.get(p.id) ?? null,
+                projectedTotal: computeProjectedTotal(ppg, expGames),
+            };
+        });
+    };
+
+    const sortPlayers = (players: any[], sort: PlayerSortBy): any[] => {
+        const sorted = [...players];
+        if (sort === 'rank') {
+            sorted.sort((a, b) => {
+                const aRank = a.rank;
+                const bRank = b.rank;
+                if (aRank != null && bRank != null) return aRank - bRank;
+                if (aRank != null) return -1;
+                if (bRank != null) return 1;
+                return (b.projectedTotal || 0) - (a.projectedTotal || 0);
+            });
+        } else if (sort === 'projection') {
+            sorted.sort((a, b) => (b.projectedTotal || 0) - (a.projectedTotal || 0));
+        }
+        // 'name' keeps the original alphabetical order from the query
+        return sorted;
+    };
 
     // Get current pick team information
     useEffect(() => {
@@ -149,8 +212,10 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
 
                 if (playersError) throw playersError;
 
-                setAvailablePlayers(players || []);
-                setSearchResults(players || []);
+                const enriched = enrichAndSort(players || []);
+                const sorted = sortPlayers(enriched, playerSortBy);
+                setAvailablePlayers(sorted);
+                setSearchResults(sorted);
             } catch (error) {
                 console.error('Error fetching available players:', error);
             } finally {
@@ -274,6 +339,13 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
         setSearchResults(filtered);
     };
 
+    const handleSortChange = (sort: PlayerSortBy) => {
+        setPlayerSortBy(sort);
+        const sorted = sortPlayers(availablePlayers, sort);
+        setAvailablePlayers(sorted);
+        setSearchResults(sorted);
+    };
+
     const isDraftActive = draftState.draft_status === 'in_progress';
     const isDraftCompleted = draftState.draft_status === 'completed';
     const isMyTurn = currentPickTeam?.id === currentTeam.id && isDraftActive;
@@ -349,7 +421,7 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                 <TabsContent value="players">
                     <div className="grid grid-cols-1 lg:grid-cols-12 gap-4">
                         {/* Player Search - main area */}
-                        <div className="lg:col-span-5">
+                        <div className={isQueueOpen ? 'lg:col-span-5' : 'lg:col-span-9'}>
                             <Card>
                                 <CardContent className="p-4">
                                     <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">Available Players</h3>
@@ -403,20 +475,48 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                                         isDraftActive={isDraftActive}
                                         selectedPlayer={selectedPlayer}
                                         leagueType={draftSettings.leagues.league}
+                                        isNcaam={isNcaam}
+                                        sortBy={playerSortBy}
+                                        onSortChange={handleSortChange}
                                     />
                                 </CardContent>
                             </Card>
                         </div>
 
-                        {/* Draft Queue */}
-                        <div className="lg:col-span-4">
-                            <Card>
-                                <CardContent className="p-4">
-                                    <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">Your Draft Queue</h3>
-                                    <DraftQueue teamId={currentTeam.id} draftId={draftSettings.id} />
-                                </CardContent>
-                            </Card>
-                        </div>
+                        {/* Draft Queue - collapsible */}
+                        {isQueueOpen ? (
+                            <div className="lg:col-span-4">
+                                <Card>
+                                    <CardContent className="p-4">
+                                        <div className="flex items-center justify-between mb-3">
+                                            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">Your Draft Queue</h3>
+                                            <button
+                                                onClick={() => setIsQueueOpen(false)}
+                                                className="text-muted-foreground hover:text-foreground transition-colors"
+                                                title="Collapse queue"
+                                            >
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                                    <polyline points="15 18 9 12 15 6" />
+                                                </svg>
+                                            </button>
+                                        </div>
+                                        <DraftQueue teamId={currentTeam.id} draftId={draftSettings.id} />
+                                    </CardContent>
+                                </Card>
+                            </div>
+                        ) : (
+                            <div className="hidden lg:flex items-start">
+                                <button
+                                    onClick={() => setIsQueueOpen(true)}
+                                    className="p-2 bg-card border border-border rounded-lg text-muted-foreground hover:text-foreground transition-colors"
+                                    title="Show queue"
+                                >
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                        <polyline points="9 18 15 12 9 6" />
+                                    </svg>
+                                </button>
+                            </div>
+                        )}
 
                         {/* Draft Info Panel */}
                         <div className="lg:col-span-3">

--- a/app/draft/[id]/page.tsx
+++ b/app/draft/[id]/page.tsx
@@ -75,11 +75,39 @@ export default async function DraftPage({
         return <div>Error loading teams</div>;
     }
 
-    const currentTeam = userTeam || { 
+    const currentTeam = userTeam || {
         id: 'commissioner',
         name: 'Commissioner View',
         league_id: draftSettings.league_id
     };
+
+    // Fetch NCAA rankings data if this is an NCAAM league
+    let userRankings: any[] = [];
+    let userTeamSettings: any[] = [];
+    let ncaaTeamInfo: any[] = [];
+
+    if (draftSettings.leagues.league === 'NCAAM') {
+        const [rankingsRes, teamSettingsRes, teamInfoRes] = await Promise.all([
+            supabase
+                .from('user_ncaa_rankings')
+                .select('*')
+                .eq('user_id', user.id)
+                .eq('season_year', 2026),
+            supabase
+                .from('user_ncaa_team_settings')
+                .select('*')
+                .eq('user_id', user.id)
+                .eq('season_year', 2026),
+            supabase
+                .from('ncaa_team_info')
+                .select('*')
+                .eq('season_year', 2026),
+        ]);
+
+        userRankings = rankingsRes.data || [];
+        userTeamSettings = teamSettingsRes.data || [];
+        ncaaTeamInfo = teamInfoRes.data || [];
+    }
 
     return (
         <div className="min-h-screen bg-background">
@@ -91,11 +119,14 @@ export default async function DraftPage({
                 </div>
 
                 <main>
-                    <DraftRoom 
-                        draftSettings={draftSettings} 
-                        currentTeam={currentTeam} 
+                    <DraftRoom
+                        draftSettings={draftSettings}
+                        currentTeam={currentTeam}
                         isCommissioner={isCommissioner}
                         leagueTeams={leagueTeams}
+                        userRankings={userRankings}
+                        userTeamSettings={userTeamSettings}
+                        ncaaTeamInfo={ncaaTeamInfo}
                     />
                 </main>
             </div>

--- a/app/draft/[id]/picks-carousel.tsx
+++ b/app/draft/[id]/picks-carousel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRef, useEffect, useMemo } from 'react';
-import { getPositionColor, getPositionBorderColor, computePickInfo, getTeamIdForPick } from './utils';
+import { getPositionColor, getPositionBorderColor, getPositionsForLeague, computePickInfo, getTeamIdForPick } from './utils';
 
 interface PicksCarouselProps {
     leagueTeams: any[];
@@ -51,6 +51,41 @@ export default function PicksCarousel({
         }
         return map;
     }, [leagueTeams]);
+
+    const positions = getPositionsForLeague(leagueType);
+
+    // Build roster counts per team: teamId -> { G: 2, F: 1, ... }
+    const teamRosters = useMemo(() => {
+        const rosters: Record<string, Record<string, number>> = {};
+        for (const pick of draftPicks) {
+            const teamId = pick.team?.id || pick.team_id;
+            const position = pick.player?.position;
+            if (teamId && position) {
+                if (!rosters[teamId]) rosters[teamId] = {};
+                rosters[teamId][position] = (rosters[teamId][position] || 0) + 1;
+            }
+        }
+        return rosters;
+    }, [draftPicks]);
+
+    // Cumulative roster at each pick number: pickNumber -> { G: x, F: y, ... }
+    const rosterAtPick = useMemo(() => {
+        const map: Record<number, Record<string, number>> = {};
+        const running: Record<string, Record<string, number>> = {};
+        // Sort picks by pick_number to build cumulative state
+        const sorted = [...draftPicks].sort((a, b) => (a.pick_number || 0) - (b.pick_number || 0));
+        for (const pick of sorted) {
+            const teamId = pick.team?.id || pick.team_id;
+            const position = pick.player?.position;
+            if (teamId && position && pick.pick_number != null) {
+                if (!running[teamId]) running[teamId] = {};
+                running[teamId][position] = (running[teamId][position] || 0) + 1;
+                // Snapshot the team's roster state at this pick
+                map[pick.pick_number] = { ...running[teamId] };
+            }
+        }
+        return map;
+    }, [draftPicks]);
 
     const currentOverallPick = (currentRound - 1) * totalTeams + currentPick;
 
@@ -109,6 +144,7 @@ export default function PicksCarousel({
                         const playerTeam = pick.player?.team || '';
                         const posColor = getPositionColor(position, leagueType);
                         const borderColor = getPositionBorderColor(position, leagueType);
+                        const roster = rosterAtPick[overallPick] || {};
 
                         return (
                             <div
@@ -134,11 +170,29 @@ export default function PicksCarousel({
                                 </div>
                                 {/* Team name */}
                                 <p className="text-[10px] text-muted-foreground truncate mt-1">{teamName}</p>
+                                {/* Roster breakdown */}
+                                <div className="flex gap-1 mt-1 flex-wrap">
+                                    {positions.map((pos) => {
+                                        const count = roster[pos] || 0;
+                                        if (count === 0) return null;
+                                        return (
+                                            <span
+                                                key={pos}
+                                                className={`text-[9px] font-medium px-1 rounded ${getPositionColor(pos, leagueType)} text-white`}
+                                            >
+                                                {pos}{count}
+                                            </span>
+                                        );
+                                    })}
+                                </div>
                             </div>
                         );
                     }
 
-                    // Empty / future pick
+                    // Empty / future pick — show current team roster
+                    const currentRoster = teamRosters[teamId] || {};
+                    const hasRoster = Object.values(currentRoster).some(c => c > 0);
+
                     return (
                         <div
                             key={overallPick}
@@ -151,6 +205,22 @@ export default function PicksCarousel({
                         >
                             <p className="text-[10px] text-muted-foreground mb-0.5">{notation}</p>
                             <p className="text-sm font-medium truncate text-muted-foreground">{teamName}</p>
+                            {hasRoster && (
+                                <div className="flex gap-1 mt-1 flex-wrap">
+                                    {positions.map((pos) => {
+                                        const count = currentRoster[pos] || 0;
+                                        if (count === 0) return null;
+                                        return (
+                                            <span
+                                                key={pos}
+                                                className={`text-[9px] font-medium px-1 rounded ${getPositionColor(pos, leagueType)} text-white`}
+                                            >
+                                                {pos}{count}
+                                            </span>
+                                        );
+                                    })}
+                                </div>
+                            )}
                         </div>
                     );
                 })}

--- a/app/draft/[id]/player-search.tsx
+++ b/app/draft/[id]/player-search.tsx
@@ -16,6 +16,8 @@ import {
     TableRow,
 } from "@/components/ui/table";
 
+type PlayerSortBy = 'rank' | 'projection' | 'name';
+
 interface PlayerSearchProps {
     availablePlayers: any[];
     searchResults: any[];
@@ -28,6 +30,9 @@ interface PlayerSearchProps {
     isDraftActive?: boolean;
     selectedPlayer: any | null;
     leagueType?: string;
+    isNcaam?: boolean;
+    sortBy?: PlayerSortBy;
+    onSortChange?: (sortBy: PlayerSortBy) => void;
 }
 
 export default function PlayerSearch({
@@ -41,7 +46,10 @@ export default function PlayerSearch({
     isCommissioner = false,
     isDraftActive = false,
     selectedPlayer,
-    leagueType = 'NFL'
+    leagueType = 'NFL',
+    isNcaam = false,
+    sortBy = 'name',
+    onSortChange,
 }: PlayerSearchProps) {
     const [searchTerm, setSearchTerm] = useState('');
     const [currentPosition, setCurrentPosition] = useState('All');
@@ -94,6 +102,29 @@ export default function PlayerSearch({
                         ))}
                     </TabsList>
                 </Tabs>
+
+                {isNcaam && onSortChange && (
+                    <div className="flex items-center gap-2">
+                        <span className="text-xs text-muted-foreground mr-1">Sort:</span>
+                        {(['rank', 'projection'] as const).map((key) => {
+                            const label = key === 'rank' ? 'Rank' : 'Projection';
+                            const isActive = sortBy === key;
+                            return (
+                                <button
+                                    key={key}
+                                    onClick={() => onSortChange(key)}
+                                    className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+                                        isActive
+                                            ? 'bg-primary text-primary-foreground'
+                                            : 'bg-muted text-muted-foreground hover:text-foreground'
+                                    }`}
+                                >
+                                    {label}
+                                </button>
+                            );
+                        })}
+                    </div>
+                )}
             </div>
 
             <div className="border border-border rounded-lg overflow-hidden">
@@ -110,11 +141,18 @@ export default function PlayerSearch({
                         <Table className="table-fixed w-full">
                             <TableHeader>
                                 <TableRow>
-                                    <TableHead className="w-[40%] xl:w-[25%]">Player</TableHead>
+                                    <TableHead className={isNcaam ? "w-[30%]" : "w-[40%] xl:w-[25%]"}>Player</TableHead>
                                     <TableHead className="w-[10%]">Pos</TableHead>
                                     <TableHead className="w-[15%]">Team</TableHead>
-                                    <TableHead className="hidden xl:table-cell xl:w-[25%]">Summary</TableHead>
-                                    <TableHead className="w-[35%] xl:w-[25%] text-right">Action</TableHead>
+                                    {isNcaam ? (
+                                        <>
+                                            <TableHead className="w-[10%] text-center">Rank</TableHead>
+                                            <TableHead className="w-[10%] text-center">Proj</TableHead>
+                                        </>
+                                    ) : (
+                                        <TableHead className="hidden xl:table-cell xl:w-[25%]">Summary</TableHead>
+                                    )}
+                                    <TableHead className={isNcaam ? "w-[25%] text-right" : "w-[35%] xl:w-[25%] text-right"}>Action</TableHead>
                                 </TableRow>
                             </TableHeader>
                             <TableBody>
@@ -138,7 +176,22 @@ export default function PlayerSearch({
                                         </TableCell>
                                         <TableCell>{player.position}</TableCell>
                                         <TableCell>{player.team_name}</TableCell>
-                                        <TableCell className="hidden xl:table-cell max-w-xs truncate">{player.summary || '-'}</TableCell>
+                                        {isNcaam ? (
+                                            <>
+                                                <TableCell className="text-center">
+                                                    {player.rank != null ? (
+                                                        <span className="text-sm font-semibold text-foreground">{player.rank}</span>
+                                                    ) : (
+                                                        <span className="text-sm text-muted-foreground">-</span>
+                                                    )}
+                                                </TableCell>
+                                                <TableCell className="text-center">
+                                                    <span className="text-sm font-semibold text-primary">{player.projectedTotal ?? '-'}</span>
+                                                </TableCell>
+                                            </>
+                                        ) : (
+                                            <TableCell className="hidden xl:table-cell max-w-xs truncate">{player.summary || '-'}</TableCell>
+                                        )}
                                         <TableCell className="text-right">
                                             <div className="flex justify-end space-x-2">
                                                 <Button


### PR DESCRIPTION
## Summary
- Fetch user's NCAA rankings, expected games, and team info server-side for NCAAM drafts
- Show **Rank** and **Proj** columns in the available players table (replaces Summary column for NCAAM only)
- Default sort by rank (ranked players first by rank_position, unranked by projection desc)
- Add **Rank/Projection sort toggle buttons** for NCAAM drafts
- Make the **draft queue collapsible** — click chevron to hide/show, player search expands to fill the space
- Add **per-team roster position breakdown** (e.g., G2 F1 C1) to carousel pick cards for both filled and future picks
- Non-NCAAM leagues (NFL/NBA) are completely unaffected

## Test plan
- [ ] Open an NCAAM draft — verify Rank and Proj columns appear in available players
- [ ] Verify default sort is by rank (ranked players first, then by projection)
- [ ] Click Projection sort — verify players reorder by projected total
- [ ] Open an NFL/NBA draft — verify Summary column still shows, no sort buttons
- [ ] Click queue collapse chevron — queue hides, player search panel expands
- [ ] Click expand button — queue reappears at original size
- [ ] Check carousel pick cards — filled picks show position breakdown (G/F/C badges)
- [ ] Check future pick cards — show the team's current overall roster breakdown
- [ ] Search/filter by position — verify sort order is maintained

🤖 Generated with [Claude Code](https://claude.ai/code)