### PR TITLE
fix: resolve RLS auth issue on invite pages

### DIFF
--- a/app/invite/league/[newleagueid]/page.tsx
+++ b/app/invite/league/[newleagueid]/page.tsx
@@ -22,7 +22,15 @@ export default async function LeagueInvite(props: { params: Promise<{ newleaguei
         );
     }
 
-    // Get league info
+    // Check auth BEFORE any DB queries so the session is resolved for RLS
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+        // Middleware should redirect unauthenticated users, but fallback just in case
+        redirect(`/login?next=/invite/league/${league_id}`);
+    }
+
+    // Get league info (requires authenticated session for RLS)
     const { data: league } = await supabase
         .from('leagues')
         .select('*')
@@ -36,13 +44,6 @@ export default async function LeagueInvite(props: { params: Promise<{ newleaguei
                 <Link href="/">Go Back to Home</Link>
             </>
         );
-    }
-
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-        // Middleware should redirect unauthenticated users, but fallback just in case
-        redirect(`/login?next=/invite/league/${league_id}`);
     }
 
     // Find all unclaimed teams in the league, sorted by name

--- a/app/invite/team/[newteamid]/page.tsx
+++ b/app/invite/team/[newteamid]/page.tsx
@@ -22,6 +22,14 @@ export default async function TeamInvite(props: { params: Promise<{ newteamid: T
         );
     }
 
+    // Check auth BEFORE any DB queries so the session is resolved for RLS
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+        // Middleware should redirect unauthenticated users, but fallback just in case
+        redirect(`/login?next=/invite/team/${team_id}`);
+    }
+
     const { data: team } = await supabase.from('teams').select('*').eq('id', team_id).single();
     if (!team) {
         return (
@@ -31,7 +39,7 @@ export default async function TeamInvite(props: { params: Promise<{ newteamid: T
             </>
         );
     }
-    
+
     // Check if team is already claimed
     if (team.user_id) {
         return (
@@ -55,13 +63,6 @@ export default async function TeamInvite(props: { params: Promise<{ newteamid: T
                 </div>
             </div>
         );
-    }
-
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-        // Middleware should redirect unauthenticated users, but fallback just in case
-        redirect(`/login?next=/invite/team/${team_id}`);
     }
 
     return (


### PR DESCRIPTION
## Summary
- Move `getUser()` call before any database queries on both league and team invite pages
- Ensures the authenticated session is established before RLS policies evaluate
- Fixes league invite links failing for newly authenticated users (DB queries returned null due to RLS rejecting unauthenticated reads)

## Test plan
- [ ] Click a league invite link while logged out → should redirect to login, then back to the invite page showing available teams
- [ ] Click a team invite link while logged out → same flow, should show the team join form
- [ ] Click a league invite link while logged in → should go directly to the invite page

🤖 Generated with [Claude Code](https://claude.ai/code)