### PR TITLE
fix: UI cleanup — migrate legacy tokens and polish interactions

### DIFF
--- a/app/draft/[id]/draft-queue.tsx
+++ b/app/draft/[id]/draft-queue.tsx
@@ -185,7 +185,7 @@ export default function DraftQueue({ teamId, draftId }: DraftQueueProps) {
                 <p className="text-center py-4">Loading your queue...</p>
             ) : availableQueuedPlayers.length === 0 ? (
                 <div className="text-center py-4">
-                    <p className="text-secondary-text mb-2">Your queue is empty.</p>
+                    <p className="text-muted-foreground mb-2">Your queue is empty.</p>
                     <p className="text-sm">Add players from the available list to create your draft priorities.</p>
                 </div>
             ) : (
@@ -208,10 +208,10 @@ export default function DraftQueue({ teamId, draftId }: DraftQueueProps) {
                                                 ref={provided.innerRef}
                                                 {...provided.draggableProps}
                                                 {...provided.dragHandleProps}
-                                                className="flex items-center p-2 border border-slate-grey rounded-lg bg-surface hover:bg-gluon-grey transition-colors"
+                                                className="flex items-center p-2 border border-slate-grey rounded-lg bg-card hover:bg-gluon-grey transition-colors"
                                             >
                                                 <div className="flex-shrink-0 mr-3">
-                                                    <div className="w-7 h-7 flex items-center justify-center bg-slate-grey text-primary-text rounded-full font-bold text-sm">
+                                                    <div className="w-7 h-7 flex items-center justify-center bg-slate-grey text-foreground rounded-full font-bold text-sm">
                                                         {index + 1}
                                                     </div>
                                                 </div>
@@ -219,7 +219,7 @@ export default function DraftQueue({ teamId, draftId }: DraftQueueProps) {
                                                 <div className="flex justify-between items-center flex-grow">
                                                     <div>
                                                         <p className="font-medium text-sm">{queueItem.player?.name}</p>
-                                                        <p className="text-xs text-secondary-text">
+                                                        <p className="text-xs text-muted-foreground">
                                                             {queueItem.player?.position} - {queueItem.player?.team_name}
                                                         </p>
                                                     </div>

--- a/app/draft/[id]/page.tsx
+++ b/app/draft/[id]/page.tsx
@@ -51,7 +51,7 @@ export default async function DraftPage({
     if (!userTeam && !isCommissioner) {
         return (
             <div className="min-h-screen bg-background flex flex-col items-center justify-center p-4">
-                <h1 className="text-2xl font-bold text-primary-text mb-4">
+                <h1 className="text-2xl font-bold text-foreground mb-4">
                     You don&apos;t have access to this draft
                 </h1>
                 <Link 
@@ -113,7 +113,7 @@ export default async function DraftPage({
         <div className="min-h-screen bg-background">
             <div className="w-full max-w-[1600px] mx-auto px-4">
                 <div className="py-6">
-                    <h1 className="text-xl font-bold text-primary-text">
+                    <h1 className="text-xl font-bold text-foreground">
                         {draftSettings.leagues.name} Draft
                     </h1>
                 </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -44,10 +44,6 @@
 
     --radius: 0.5rem;
 
-    /* Legacy semantic aliases (for existing classes during migration) */
-    --surface: var(--gluon-grey);
-    --primary-text: var(--snow);
-    --secondary-text: var(--dusty-grey);
   }
 
   /* Light mode */
@@ -80,10 +76,6 @@
     --input: 0 0% 87%;
     --ring: 24 92% 51%;               /* liquid-lava */
 
-    /* Legacy aliases */
-    --surface: #f0f0f0;
-    --primary-text: var(--dark-void);
-    --secondary-text: #444444;
   }
 
   /* Midnight — deep navy blue */
@@ -116,9 +108,6 @@
     --input: 222 25% 18%;
     --ring: 210 100% 56%;
 
-    --surface: #121D33;
-    --primary-text: #EFF3FA;
-    --secondary-text: #7B8FAD;
   }
 
   /* Forest — rich dark greens */
@@ -151,9 +140,6 @@
     --input: 150 12% 18%;
     --ring: 142 70% 45%;
 
-    --surface: #162220;
-    --primary-text: #E8EDE9;
-    --secondary-text: #6E8B7B;
   }
 
   /* Crimson — deep reds, bold sports energy */
@@ -186,9 +172,6 @@
     --input: 0 10% 18%;
     --ring: 0 85% 55%;
 
-    --surface: #221818;
-    --primary-text: #F2EEEE;
-    --secondary-text: #8B6E6E;
   }
 
   /* Sunset — warm amber and purple tones */
@@ -221,9 +204,6 @@
     --input: 270 15% 19%;
     --ring: 32 95% 55%;
 
-    --surface: #1E1528;
-    --primary-text: #F5F0E6;
-    --secondary-text: #8B7A9B;
   }
 
   /* Arctic — icy light blues, clean */
@@ -256,9 +236,6 @@
     --input: 205 20% 85%;
     --ring: 200 90% 45%;
 
-    --surface: #FFFFFF;
-    --primary-text: #17232E;
-    --secondary-text: #55687A;
   }
 
   /* System preference light mode */
@@ -292,9 +269,6 @@
       --input: 0 0% 87%;
       --ring: 24 92% 51%;
 
-      --surface: #f0f0f0;
-      --primary-text: var(--dark-void);
-      --secondary-text: #444444;
     }
   }
 

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useMemo } from 'react';
+import { ChevronUp, ChevronDown } from 'lucide-react';
 import Teams from './teams';
 
 const CURRENT_YEAR = 2026;
@@ -34,11 +35,11 @@ export default function HomeContent({ teams }: { teams: TeamWithLeague[] }) {
         <div className="border-t border-border">
           <button
             onClick={() => setShowPreviousYears(!showPreviousYears)}
-            className="w-full px-4 py-3 flex items-center justify-between text-secondary-text hover:text-primary-text hover:bg-surface transition-colors"
+            className="w-full px-4 py-3 flex items-center justify-between text-muted-foreground hover:text-foreground hover:bg-card transition-colors cursor-pointer"
           >
             <span className="font-medium">Previous Leagues</span>
-            <span className="text-sm">
-              {showPreviousYears ? '▲ Hide' : '▼ Show'} ({previousYearTeams.length})
+            <span className="text-sm flex items-center gap-1">
+              {showPreviousYears ? <><ChevronUp size={14} /> Hide</> : <><ChevronDown size={14} /> Show</>} ({previousYearTeams.length})
             </span>
           </button>
 

--- a/app/invite/league/[newleagueid]/page.tsx
+++ b/app/invite/league/[newleagueid]/page.tsx
@@ -58,16 +58,16 @@ export default async function LeagueInvite(props: { params: Promise<{ newleaguei
         return (
             <div className='w-full max-w-xl mx-auto'>
                 <div className='flex justify-between px-4 py-6 border border-border'>
-                    <Link className='text-xl font-bold text-primary-text hover:text-accent transition-colors' href={'/'}>Home</Link>
-                    <h1 className='text-xl font-bold text-primary-text'>League Invite</h1>
+                    <Link className='text-xl font-bold text-foreground hover:text-accent transition-colors' href={'/'}>Home</Link>
+                    <h1 className='text-xl font-bold text-foreground'>League Invite</h1>
                     <div className="flex items-center gap-4">
                         <ThemeToggle />
                         <AuthButtonServer />
                     </div>
                 </div>
-                <div className="flex-1 flex flex-col justify-center items-center p-8 bg-surface rounded-lg border border-border mt-4">
-                    <h2 className="text-2xl font-bold mb-4 text-primary-text">No Available Teams</h2>
-                    <p className="text-center mb-4 text-secondary-text">
+                <div className="flex-1 flex flex-col justify-center items-center p-8 bg-card rounded-lg border border-border mt-4">
+                    <h2 className="text-2xl font-bold mb-4 text-foreground">No Available Teams</h2>
+                    <p className="text-center mb-4 text-muted-foreground">
                         Sorry, there are no available teams in {league.name}. All teams have been claimed.
                     </p>
                     <Link href="/" className="text-accent hover:opacity-80 transition-opacity">
@@ -81,17 +81,17 @@ export default async function LeagueInvite(props: { params: Promise<{ newleaguei
     return (
         <div className='w-full max-w-xl mx-auto'>
             <div className='flex justify-between px-4 py-6 border border-border'>
-                <Link className='text-xl font-bold text-primary-text hover:text-accent transition-colors' href={'/'}>Home</Link>
-                <h1 className='text-xl font-bold text-primary-text'>League Invite</h1>
+                <Link className='text-xl font-bold text-foreground hover:text-accent transition-colors' href={'/'}>Home</Link>
+                <h1 className='text-xl font-bold text-foreground'>League Invite</h1>
                 <div className="flex items-center gap-4">
                     <ThemeToggle />
                     <AuthButtonServer />
                 </div>
             </div>
-            <div className="flex-1 flex flex-col justify-center items-center p-8 bg-surface rounded-lg border border-border mt-4">
+            <div className="flex-1 flex flex-col justify-center items-center p-8 bg-card rounded-lg border border-border mt-4">
                 <div className="text-center mb-6">
-                    <h2 className="text-2xl font-bold mb-2 text-primary-text">Join {league.name}</h2>
-                    <p className="text-secondary-text">Select a team to join</p>
+                    <h2 className="text-2xl font-bold mb-2 text-foreground">Join {league.name}</h2>
+                    <p className="text-muted-foreground">Select a team to join</p>
                 </div>
                 <AddToTeam user={user} teams={teams} />
             </div>

--- a/app/invite/team/[newteamid]/add-to-team.tsx
+++ b/app/invite/team/[newteamid]/add-to-team.tsx
@@ -43,12 +43,12 @@ export default function AddToTeam({user, team_name, team_id}: { user: User, team
         <div className="w-full max-w-md p-6">
             <div className="text-center mb-6">
                 <h2 className="text-2xl font-bold mb-2">Join Team</h2>
-                <p className="text-secondary-text">You&apos;re about to join as: {team_name}</p>
+                <p className="text-muted-foreground">You&apos;re about to join as: {team_name}</p>
             </div>
             
             <form onSubmit={handleSubmit} className="space-y-4">
                 <div>
-                    <label htmlFor="TeamName" className="block text-sm text-secondary-text mb-1">
+                    <label htmlFor="TeamName" className="block text-sm text-muted-foreground mb-1">
                         You can customize your team name (optional):
                     </label>
                     <input 
@@ -56,7 +56,7 @@ export default function AddToTeam({user, team_name, team_id}: { user: User, team
                         name="TeamName" 
                         type="text" 
                         placeholder={team_name}
-                        className="w-full bg-surface text-primary-text border border-slate-grey rounded-lg px-4 py-2 focus:border-liquid-lava focus:outline-none transition-colors"
+                        className="w-full bg-card text-foreground border border-slate-grey rounded-lg px-4 py-2 focus:border-liquid-lava focus:outline-none transition-colors"
                     />
                 </div>
                 

--- a/app/invite/team/[newteamid]/page.tsx
+++ b/app/invite/team/[newteamid]/page.tsx
@@ -45,16 +45,16 @@ export default async function TeamInvite(props: { params: Promise<{ newteamid: T
         return (
             <div className='w-full max-w-xl mx-auto p-6'>
                 <div className='flex justify-between px-4 py-6 border border-border'>
-                    <Link className='text-xl font-bold text-primary-text hover:text-accent transition-colors' href={'/'}>Home</Link>
-                    <h1 className='text-xl font-bold text-primary-text'>Team Already Claimed</h1>
+                    <Link className='text-xl font-bold text-foreground hover:text-accent transition-colors' href={'/'}>Home</Link>
+                    <h1 className='text-xl font-bold text-foreground'>Team Already Claimed</h1>
                     <div className="flex items-center gap-4">
                         <ThemeToggle />
                         <AuthButtonServer />
                     </div>
                 </div>
-                <div className="flex-1 flex flex-col items-center justify-center p-8 text-center bg-surface rounded-lg border border-border mt-4">
-                    <h2 className="text-2xl font-bold mb-4 text-primary-text">This Team Has Already Been Claimed</h2>
-                    <p className="mb-4 text-secondary-text">
+                <div className="flex-1 flex flex-col items-center justify-center p-8 text-center bg-card rounded-lg border border-border mt-4">
+                    <h2 className="text-2xl font-bold mb-4 text-foreground">This Team Has Already Been Claimed</h2>
+                    <p className="mb-4 text-muted-foreground">
                         The team &quot;{team.name}&quot; has already been claimed by another user.
                     </p>
                     <Link href="/" className="text-accent hover:opacity-80 transition-opacity">
@@ -68,14 +68,14 @@ export default async function TeamInvite(props: { params: Promise<{ newteamid: T
     return (
         <div className='w-full max-w-xl mx-auto'>
             <div className='flex justify-between px-4 py-6 border border-slate-grey'>
-                <Link className='text-xl font-bold text-primary-text hover:text-liquid-lava transition-colors' href={'/'}>Home</Link>
-                <h1 className='text-xl font-bold text-primary-text'>Team Invite</h1>
+                <Link className='text-xl font-bold text-foreground hover:text-liquid-lava transition-colors' href={'/'}>Home</Link>
+                <h1 className='text-xl font-bold text-foreground'>Team Invite</h1>
                 <div className="flex items-center gap-4">
                     <ThemeToggle />
                     <AuthButtonServer />
                 </div>
             </div>
-            <div className="flex-1 flex flex-col justify-center items-center bg-surface p-6 rounded-lg border border-slate-grey">
+            <div className="flex-1 flex flex-col justify-center items-center bg-card p-6 rounded-lg border border-slate-grey">
                 <AddToTeam user={user} team_name={team.name} team_id={team_id} />
             </div>
         </div>

--- a/app/league/[id]/league-home.tsx
+++ b/app/league/[id]/league-home.tsx
@@ -210,7 +210,7 @@ export default function LeagueHome({ teams, league_id, league, draftSettings, is
                 {sortedTeams.map(team => (
                     <div
                         key={team.id}
-                        className="border border-border bg-card hover:bg-opacity-80 transition-colors duration-200 rounded-lg px-6 py-6"
+                        className="border border-border bg-card hover:brightness-110 transition-all duration-200 rounded-lg px-6 py-6"
                     >
                         <div className="flex justify-between items-center">
                             <div className="space-y-2">

--- a/app/league/[id]/page.tsx
+++ b/app/league/[id]/page.tsx
@@ -22,7 +22,7 @@ export default async function League(props: { params: Promise<{ id: LeagueID }> 
     if (!leagueId) {
         return (
             <div className="min-h-screen bg-background flex flex-col items-center justify-center p-4">
-                <h1 className="text-2xl font-bold text-primary-text mb-4">
+                <h1 className="text-2xl font-bold text-foreground mb-4">
                     Error: Invalid League
                 </h1>
                 <Link 
@@ -214,13 +214,13 @@ export default async function League(props: { params: Promise<{ id: LeagueID }> 
         <div className="min-h-screen bg-background">
             <div className="w-full max-w-4xl mx-auto px-4">
                 <div className="py-6">
-                    <h1 className="text-xl font-bold text-primary-text">
+                    <h1 className="text-xl font-bold text-foreground">
                         {leagueData.name}
                     </h1>
                 </div>
 
                 <main>
-                    <div className="bg-surface rounded-xl p-6 shadow-lg">
+                    <div className="bg-card rounded-xl p-6 shadow-lg">
                         <LeagueHome
                             teams={teams}
                             league_id={params.id}

--- a/app/league/[id]/team/[teamid]/page.tsx
+++ b/app/league/[id]/team/[teamid]/page.tsx
@@ -29,7 +29,7 @@ export default async function Team(props: { params: Promise<{ teamid: TeamID }> 
         return (
             <div className="min-h-screen bg-background">
                 <div className="max-w-xl mx-auto p-6">
-                    <h1 className="text-primary-text text-2xl font-bold mb-4">Error, invalid team</h1>
+                    <h1 className="text-foreground text-2xl font-bold mb-4">Error, invalid team</h1>
                     <Link href="/" className="text-accent hover:opacity-80 transition-opacity">
                         Go Back to Home
                     </Link>
@@ -151,12 +151,12 @@ export default async function Team(props: { params: Promise<{ teamid: TeamID }> 
         <div className="min-h-screen bg-background">
             <div className="max-w-xl mx-auto">
                 <nav className="flex justify-between items-center px-6 py-4 border-b border-border">
-                    <Link href="/" className="text-lg font-bold text-primary-text hover:text-accent transition-colors">
+                    <Link href="/" className="text-lg font-bold text-foreground hover:text-accent transition-colors">
                         Home
                     </Link>
                     <Link 
                         href={`/league/${team.leagues?.id}`} 
-                        className="text-lg font-bold text-primary-text hover:text-accent transition-colors"
+                        className="text-lg font-bold text-foreground hover:text-accent transition-colors"
                     >
                         League Home
                     </Link>
@@ -174,7 +174,7 @@ export default async function Team(props: { params: Promise<{ teamid: TeamID }> 
         <div className="p-6">
             <div className="mb-6">
                 <TeamHeader team={team} isAuthorized={isAuthorized} isOwner={isOwner} isCommissioner={isCommissioner} />
-                <h2 className="text-secondary-text">{teamData.owner?.full_name || 'Unclaimed'}</h2>
+                <h2 className="text-muted-foreground">{teamData.owner?.full_name || 'Unclaimed'}</h2>
             </div>
 
             {teamData.league?.scoring_type === 'NFL Playoff Pickem' ? (

--- a/app/league/[id]/team/[teamid]/search-component.tsx
+++ b/app/league/[id]/team/[teamid]/search-component.tsx
@@ -13,10 +13,10 @@ const SearchComponent: React.FC<SearchComponentProps> = ({ onSearch }) => {
   };
 
   return (
-    <div className='bg-surface border border-border p-3 rounded-lg my-4'>
+    <div className='bg-card border border-border p-3 rounded-lg my-4'>
       <div className="flex items-center gap-2">
         <input
-          className='flex-grow bg-inherit text-primary-text placeholder:text-secondary-text focus:outline-none'
+          className='flex-grow bg-inherit text-foreground placeholder:text-muted-foreground focus:outline-none'
           type="text"
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}

--- a/app/league/[id]/team/[teamid]/search-page.tsx
+++ b/app/league/[id]/team/[teamid]/search-page.tsx
@@ -48,8 +48,8 @@ const SearchPage: React.FC<{ sports_league: LeagueSportsLeague, team: TeamWithPl
     };
 
     return (
-        <div className="bg-surface p-4 rounded-lg border border-border">
-            <h2 className="text-xl font-bold text-primary-text mb-4">Add Players to Roster</h2>
+        <div className="bg-card p-4 rounded-lg border border-border">
+            <h2 className="text-xl font-bold text-foreground mb-4">Add Players to Roster</h2>
             <SearchComponent onSearch={handleSearch} />
             
             {searchResults.length > 0 ? (
@@ -57,11 +57,11 @@ const SearchPage: React.FC<{ sports_league: LeagueSportsLeague, team: TeamWithPl
                     {searchResults.map((player) => (
                         <div 
                             key={`${player.id}`}
-                            className="flex items-center justify-between p-3 bg-background rounded-lg hover:bg-surface transition-colors"
+                            className="flex items-center justify-between p-3 bg-background rounded-lg hover:bg-card transition-colors"
                         >
                             <div>
-                                <span className="font-medium text-primary-text">{player.name}</span>
-                                <span className="ml-2 text-sm text-secondary-text">{player.team_name}</span>
+                                <span className="font-medium text-foreground">{player.name}</span>
+                                <span className="ml-2 text-sm text-muted-foreground">{player.team_name}</span>
                             </div>
                             <button 
                                 onClick={() => UpdatePlayer(player.id)}
@@ -73,7 +73,7 @@ const SearchPage: React.FC<{ sports_league: LeagueSportsLeague, team: TeamWithPl
                     ))}
                 </div>
             ) : (
-                <div className="text-secondary-text text-center py-4">
+                <div className="text-muted-foreground text-center py-4">
                     Search for players to add to your team
                 </div>
             )}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -30,11 +30,11 @@ export default async function Login({ searchParams }: LoginProps) {
         <main className="flex-1 flex flex-col items-center justify-center p-4 md:p-6">
           <div className="w-full max-w-md space-y-8">
             <div className="text-center animate-fadeIn">
-              <h1 className="text-5xl font-bold text-primary-text mb-3 animate-slideDown">Welcome</h1>
-              <p className="text-lg text-secondary-text animate-slideUp">Sign in to continue to Fanteasy</p>
+              <h1 className="text-5xl font-bold text-foreground mb-3 animate-slideDown">Welcome</h1>
+              <p className="text-lg text-muted-foreground animate-slideUp">Sign in to continue to Fanteasy</p>
             </div>
             
-            <div className="space-y-8 bg-surface/80 backdrop-blur-sm p-8 rounded-2xl border border-border/50 shadow-xl">
+            <div className="space-y-8 bg-card/80 backdrop-blur-sm p-8 rounded-2xl border border-border/50 shadow-xl">
               <div className="w-full">
                 <GoogleButton redirectPath={redirectPath} />
               </div>
@@ -44,7 +44,7 @@ export default async function Login({ searchParams }: LoginProps) {
                   <div className="w-full border-t border-border/50"></div>
                 </div>
                 <div className="relative flex justify-center text-sm">
-                  <span className="px-4 bg-surface text-secondary-text">Or continue with email</span>
+                  <span className="px-4 bg-card text-muted-foreground">Or continue with email</span>
                 </div>
               </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,11 +28,11 @@ export default async function Home() {
   })) ?? []
 
   return (
-    <div className="w-full max-w-xl mx-auto bg-background text-primary-text">
+    <div className="w-full max-w-xl mx-auto bg-background text-foreground">
       <div className="px-4 py-6">
         <h1 className="text-xl font-bold">My Teams</h1>
       </div>
-      <div className="flex-1 bg-surface">
+      <div className="flex-1 bg-card">
         <div className="flex justify-end p-4">
           <Link
             href="/new-league"

--- a/app/teams.tsx
+++ b/app/teams.tsx
@@ -5,12 +5,12 @@ import Link from 'next/link';
 
 export default function Teams({ teams }: { teams: TeamWithLeague[] }){
     return teams.map(team => ( 
-        <div key={team.id} className="px-4 py-8 flex border-b border-border hover:bg-surface transition-colors">
+        <div key={team.id} className="px-4 py-8 flex border-b border-border hover:bg-card transition-colors cursor-pointer">
             <div className="h-12 w-12">
                 <Image 
                     className="rounded-full" 
                     src={team.author.avatar_url} 
-                    alt="team user avatar" 
+                    alt={`${team.name} avatar`} 
                     width={48} 
                     height={48}
                 />
@@ -27,7 +27,7 @@ export default function Teams({ teams }: { teams: TeamWithLeague[] }){
                 <p>
                     <Link 
                         href={`/league/${team.league.id}`} 
-                        className="text-secondary-text hover:text-accent transition-colors"
+                        className="text-muted-foreground hover:text-accent transition-colors"
                     >
                         {team.league.name}
                     </Link>

--- a/app/theme-toggle.tsx
+++ b/app/theme-toggle.tsx
@@ -1,15 +1,16 @@
 'use client'
 
 import { useEffect, useState, useRef } from 'react'
+import { Moon, Sun, Stars, TreePine, Flame, Sunset, Snowflake } from 'lucide-react'
 
 const THEMES = [
-  { id: 'dark', label: 'Dark', icon: '🌑', description: 'Default dark' },
-  { id: 'light', label: 'Light', icon: '☀️', description: 'Clean light' },
-  { id: 'midnight', label: 'Midnight', icon: '🌌', description: 'Deep navy' },
-  { id: 'forest', label: 'Forest', icon: '🌲', description: 'Rich greens' },
-  { id: 'crimson', label: 'Crimson', icon: '🔴', description: 'Bold reds' },
-  { id: 'sunset', label: 'Sunset', icon: '🌅', description: 'Warm amber' },
-  { id: 'arctic', label: 'Arctic', icon: '❄️', description: 'Icy blues' },
+  { id: 'dark', label: 'Dark', icon: Moon, description: 'Default dark' },
+  { id: 'light', label: 'Light', icon: Sun, description: 'Clean light' },
+  { id: 'midnight', label: 'Midnight', icon: Stars, description: 'Deep navy' },
+  { id: 'forest', label: 'Forest', icon: TreePine, description: 'Rich greens' },
+  { id: 'crimson', label: 'Crimson', icon: Flame, description: 'Bold reds' },
+  { id: 'sunset', label: 'Sunset', icon: Sunset, description: 'Warm amber' },
+  { id: 'arctic', label: 'Arctic', icon: Snowflake, description: 'Icy blues' },
 ] as const
 
 type ThemeId = (typeof THEMES)[number]['id']
@@ -69,7 +70,7 @@ export default function ThemeToggle() {
         aria-label="Change theme"
         aria-expanded={open}
       >
-        <span>{current.icon}</span>
+        <current.icon size={14} />
         <span>{current.label}</span>
       </button>
 
@@ -83,7 +84,7 @@ export default function ThemeToggle() {
                 theme === t.id ? 'bg-muted font-medium' : ''
               }`}
             >
-              <span className="w-5 text-center">{t.icon}</span>
+              <span className="w-5 flex items-center justify-center"><t.icon size={14} /></span>
               <div className="text-left">
                 <div>{t.label}</div>
                 <div className="text-muted-foreground text-[10px]">{t.description}</div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,11 +17,6 @@ const config: Config = {
         'gluon-grey': '#1B1B1E',
         'slate-grey': '#262626',
 
-        // Legacy semantic aliases (use during migration, remove in Phase 4)
-        'surface': 'var(--surface)',
-        'primary-text': 'var(--primary-text)',
-        'secondary-text': 'var(--secondary-text)',
-
         // shadcn semantic colors (HSL from CSS variables)
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',


### PR DESCRIPTION
## Summary
- Migrated all legacy color tokens (`text-primary-text`, `text-secondary-text`, `bg-surface`) to shadcn semantic tokens (`text-foreground`, `text-muted-foreground`, `bg-card`) across 15 files
- Removed unused legacy CSS variables and Tailwind aliases from `globals.css` and `tailwind.config.ts`
- Replaced emoji icons in theme toggle with Lucide SVG icons (Moon, Sun, Stars, TreePine, Flame, Sunset, Snowflake)
- Replaced text arrows (▲/▼) with Lucide ChevronUp/ChevronDown in Previous Leagues toggle
- Fixed non-functional `hover:bg-opacity-80` in league home (→ `hover:brightness-110`)
- Added `cursor-pointer` to interactive team rows and Previous Leagues toggle
- Fixed generic alt text on team avatars to use actual team name

## Test plan
- [x] Toggle all 7 themes and verify colors render correctly (no missing/broken styles)
- [x] Check theme toggle dropdown renders SVG icons instead of emojis
- [x] Verify Previous Leagues toggle shows chevron icons and has pointer cursor
- [x] Hover over team rows on league home page — should brighten subtly
- [x] Hover over team rows on home page — should show pointer cursor
- [x] Inspect team avatar alt text in dev tools — should show team name

🤖 Generated with [Claude Code](https://claude.ai/code)