### PR TITLE
feat: toast notifications, auth fix, accessibility & mobile improvements

### DIFF
--- a/app/auth-button-client.tsx
+++ b/app/auth-button-client.tsx
@@ -4,9 +4,9 @@ import { createClient } from "./utils/supabase/client";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 
-import type { Session } from "@supabase/supabase-js";
+import type { User } from "@supabase/supabase-js";
 
-export default function AuthButtonClient({ session } : { session: Session | null}) {
+export default function AuthButtonClient({ user } : { user: User | null}) {
     const supabase = createClient();
     const router = useRouter();
 
@@ -24,9 +24,9 @@ export default function AuthButtonClient({ session } : { session: Session | null
         });
     };
 
-    return session ? (
-        <Button variant="ghost" size="sm" className="text-xs text-gray-400" onClick={handleSignOut}>Logout</Button>
+    return user ? (
+        <Button variant="ghost" size="sm" className="text-xs text-muted-foreground" onClick={handleSignOut}>Logout</Button>
     ) : (
-        <Button variant="ghost" size="sm" className="text-xs text-gray-400" onClick={handleSignIn}>Login</Button>
+        <Button variant="ghost" size="sm" className="text-xs text-muted-foreground" onClick={handleSignIn}>Login</Button>
     );
 }

--- a/app/auth-button-server.tsx
+++ b/app/auth-button-server.tsx
@@ -7,8 +7,8 @@ export default async function AuthButtonServer() {
     const supabase = await createClient();
 
     const {
-        data: { session },
-    } = await supabase.auth.getSession();
+        data: { user },
+    } = await supabase.auth.getUser();
 
-    return <AuthButtonClient session={session} />;
+    return <AuthButtonClient user={user} />;
 }

--- a/app/draft/[id]/draft-queue.tsx
+++ b/app/draft/[id]/draft-queue.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { createClient } from '@/app/utils/supabase/client';
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
+import { toast } from 'sonner';
 
 interface DraftQueueProps {
     teamId: string;
@@ -121,7 +122,7 @@ export default function DraftQueue({ teamId, draftId }: DraftQueueProps) {
                 stack: error?.stack,
                 details: error?.details
             });
-            alert(`Failed to add player to queue: ${error?.message || 'Unknown error'}`);
+            toast.error(`Failed to add player to queue: ${error?.message || 'Unknown error'}`);
         }
     };
     
@@ -136,7 +137,7 @@ export default function DraftQueue({ teamId, draftId }: DraftQueueProps) {
             if (error) throw error;
         } catch (error) {
             console.error('Error removing player from queue:', error);
-            alert('Failed to remove player from queue.');
+            toast.error('Failed to remove player from queue.');
         }
     };
     
@@ -170,7 +171,7 @@ export default function DraftQueue({ teamId, draftId }: DraftQueueProps) {
             }
         } catch (error) {
             console.error('Error updating queue priorities:', error);
-            alert('Failed to update queue order.');
+            toast.error('Failed to update queue order.');
         }
     };
     

--- a/app/draft/[id]/draft-room.tsx
+++ b/app/draft/[id]/draft-room.tsx
@@ -8,6 +8,7 @@ import PicksCarousel from './picks-carousel';
 import DraftBoardGrid from './draft-board-grid';
 import DraftInfoPanel from './draft-info-panel';
 import { makePick, startDraft, togglePause, toggleAutoPick, triggerAutoPick } from './actions';
+import { toast } from 'sonner';
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { getDefaultExpectedGames, parsePlayerSummary, computeProjectedTotal } from '@/app/rankings/ncaa/utils';
@@ -287,7 +288,7 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
         startTransition(async () => {
             const result = await startDraft(draftSettings.id);
             if (!result.success) {
-                alert(result.error || 'Failed to start draft');
+                toast.error(result.error || 'Failed to start draft');
             }
         });
     };
@@ -296,7 +297,7 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
         startTransition(async () => {
             const result = await togglePause(draftSettings.id);
             if (!result.success) {
-                alert(result.error || 'Failed to toggle pause');
+                toast.error(result.error || 'Failed to toggle pause');
             }
         });
     };
@@ -307,7 +308,7 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
         startTransition(async () => {
             const result = await toggleAutoPick(currentTeam.id);
             if (!result.success) {
-                alert(result.error || 'Failed to update auto-pick preference');
+                toast.error(result.error || 'Failed to update auto-pick preference');
             } else {
                 setAutoPickEnabled(result.data.autoPickEnabled);
             }
@@ -446,7 +447,7 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
                                                 if (queueError) throw queueError;
 
                                                 if (currentQueue?.some(item => item.player_id === player.id)) {
-                                                    alert('This player is already in your queue.');
+                                                    toast.warning('This player is already in your queue.');
                                                     return;
                                                 }
 
@@ -464,10 +465,10 @@ export default function DraftRoom({ draftSettings, currentTeam, isCommissioner, 
 
                                                 if (error) throw error;
 
-                                                alert('Player added to your queue!');
+                                                toast.success('Player added to your queue!');
                                             } catch (error: any) {
                                                 console.error('Error adding player to queue:', error);
-                                                alert(`Failed to add player to queue: ${error?.message || 'Unknown error'}`);
+                                                toast.error(`Failed to add player to queue: ${error?.message || 'Unknown error'}`);
                                             }
                                         }}
                                         isMyTurn={isMyTurn}

--- a/app/globals.css
+++ b/app/globals.css
@@ -325,3 +325,11 @@
     animation: slideUp 0.8s ease-out 0.2s both;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -35,7 +35,7 @@ export default function HomeContent({ teams }: { teams: TeamWithLeague[] }) {
         <div className="border-t border-border">
           <button
             onClick={() => setShowPreviousYears(!showPreviousYears)}
-            className="w-full px-4 py-3 flex items-center justify-between text-muted-foreground hover:text-foreground hover:bg-card transition-colors cursor-pointer"
+            className="w-full px-4 py-3 flex items-center justify-between text-muted-foreground hover:text-foreground hover:bg-card transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
             <span className="font-medium">Previous Leagues</span>
             <span className="text-sm flex items-center gap-1">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css'
 import ThemeInitializer from './theme-initializer'
 import NavBar from './components/nav-bar'
 import { cn } from "@/lib/utils";
+import { Toaster } from 'sonner';
 
 const geist = Geist({subsets:['latin'],variable:'--font-sans'});
 
@@ -23,8 +24,14 @@ export default function RootLayout({
     <html lang="en" className={cn("font-sans", geist.variable)}>
       <ThemeInitializer />
       <body className={inter.className}>
+        <a href="#main-content" className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-md focus:text-sm">
+          Skip to content
+        </a>
         <NavBar />
-        {children}
+        <main id="main-content">
+          {children}
+        </main>
+        <Toaster richColors position="bottom-right" />
       </body>
     </html>
   )

--- a/app/league/[id]/league-home.tsx
+++ b/app/league/[id]/league-home.tsx
@@ -10,6 +10,7 @@ import { createClient } from "../../utils/supabase/client";
 import DraftStatusPanel from './draft-status-panel';
 import { useRouter } from 'next/navigation';
 import { Plus, Settings } from 'lucide-react';
+import { toast } from 'sonner';
 import LeagueSettingsModal from './league-settings-modal';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -58,7 +59,7 @@ export default function LeagueHome({ teams, league_id, league, draftSettings, is
     const copyToClipboard = async (text: string) => {
         try {
             await navigator.clipboard.writeText(text);
-            alert('Link copied to clipboard!');
+            toast.success('Link copied to clipboard!');
         } catch (err) {
             console.error('Failed to copy text: ', err);
         }
@@ -103,26 +104,29 @@ export default function LeagueHome({ teams, league_id, league, draftSettings, is
             {isCommissioner && (
                 <Card className="mb-6">
                     <CardContent className="p-4">
-                        <div className="flex items-center justify-between">
+                        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
                             <h3 className="text-lg font-semibold text-foreground">Commissioner Controls</h3>
-                            <div className="flex items-center gap-2">
+                            <div className="flex items-center flex-wrap gap-2">
                                 <Button
                                     variant="outline"
+                                    size="sm"
                                     onClick={() => setShowSettings(true)}
                                 >
-                                    <Settings size={18} />
+                                    <Settings size={16} />
                                     Settings
                                 </Button>
                                 <Button
+                                    size="sm"
                                     onClick={() => setShowAddTeam(true)}
                                 >
-                                    <Plus size={18} />
+                                    <Plus size={16} />
                                     Add Team
                                 </Button>
                                 <Button
+                                    size="sm"
                                     onClick={() => copyToClipboard(`${window.location.origin}/invite/league/${league_id}`)}
                                 >
-                                    Copy League Invite Link
+                                    Copy Invite Link
                                 </Button>
                             </div>
                         </div>
@@ -200,7 +204,7 @@ export default function LeagueHome({ teams, league_id, league, draftSettings, is
             {weeks.length > 0 && (
                 <div className="flex justify-end items-center gap-4 px-6 py-2 text-sm text-muted-foreground">
                     {weeks.map(week => (
-                        <span key={week} className="w-16 text-center">Wk {week}</span>
+                        <span key={week} className="hidden sm:inline-block w-16 text-center">Wk {week}</span>
                     ))}
                     <span className="w-20 text-center">Total</span>
                 </div>
@@ -234,7 +238,7 @@ export default function LeagueHome({ teams, league_id, league, draftSettings, is
                                     </Button>
                                 )}
                                 {weeks.map(week => (
-                                    <span key={week} className="w-16 text-center text-muted-foreground">
+                                    <span key={week} className="hidden sm:inline-block w-16 text-center text-muted-foreground">
                                         {Number(team.weeklyScores[week] || 0).toFixed(1)}
                                     </span>
                                 ))}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,12 +1,22 @@
 export default function Loading() {
   return (
-    <div className="min-h-screen bg-background flex items-center justify-center">
-      <div className="flex flex-col items-center gap-4">
-        <div className="relative w-12 h-12">
-          <div className="absolute inset-0 rounded-full border-4 border-border"></div>
-          <div className="absolute inset-0 rounded-full border-4 border-liquid-lava border-t-transparent animate-spin"></div>
+    <div className="w-full max-w-xl mx-auto bg-background text-foreground">
+      <div className="px-4 py-6">
+        <div className="h-7 w-32 bg-card rounded animate-pulse"></div>
+      </div>
+      <div className="flex-1 bg-card">
+        <div className="flex justify-end p-4">
+          <div className="h-10 w-48 bg-muted rounded-lg animate-pulse"></div>
         </div>
-        <p className="text-muted-foreground text-sm">Loading...</p>
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="px-4 py-8 flex border-b border-border">
+            <div className="h-12 w-12 rounded-full bg-muted animate-pulse"></div>
+            <div className="ml-4 space-y-2">
+              <div className="h-5 w-36 bg-muted rounded animate-pulse"></div>
+              <div className="h-4 w-24 bg-muted rounded animate-pulse"></div>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -15,9 +15,9 @@ export default async function Login({ searchParams }: LoginProps) {
     const { next: redirectPath } = await searchParams;
     const supabase = await createClient();
 
-    const {data : { session }} = await supabase.auth.getSession();
+    const {data : { user }} = await supabase.auth.getUser();
 
-    if (session) {
+    if (user) {
         redirect(redirectPath || '/');
     }
     

--- a/app/theme-toggle.tsx
+++ b/app/theme-toggle.tsx
@@ -80,7 +80,7 @@ export default function ThemeToggle() {
             <button
               key={t.id}
               onClick={() => selectTheme(t.id)}
-              className={`w-full flex items-center gap-2 px-3 py-2 text-xs transition-colors hover:bg-muted ${
+              className={`w-full flex items-center gap-2 px-3 py-2 text-xs transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
                 theme === t.id ? 'bg-muted font-medium' : ''
               }`}
             >

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "next": "15.1.11",
         "react": "19.0.0",
         "react-dom": "19.0.0",
+        "sonner": "^2.0.7",
         "supabase": "^2.9.6",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7"
@@ -9604,6 +9605,16 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "next": "15.1.11",
     "react": "19.0.0",
     "react-dom": "19.0.0",
+    "sonner": "^2.0.7",
     "supabase": "^2.9.6",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7"


### PR DESCRIPTION
## Summary
- **Toast system**: Installed `sonner` and replaced all 10 `alert()` calls across draft-room, draft-queue, and league-home with `toast.success()` / `toast.error()` / `toast.warning()`
- **Auth security**: Replaced deprecated `getSession()` with `getUser()` in login page and auth-button-server (validates JWT server-side)
- **Auth button styling**: Fixed hardcoded `text-gray-400` → `text-muted-foreground` so it respects active theme
- **Reduced motion**: Added `prefers-reduced-motion: reduce` CSS media query to disable animations for users who need it
- **Mobile responsiveness**: Commissioner controls now wrap on small screens; weekly score columns hidden on mobile (only total shown)
- **Keyboard accessibility**: Added skip-to-content link in root layout, focus-visible rings on theme toggle items and Previous Leagues button
- **Loading skeleton**: Replaced generic spinner on home page with card-shaped skeleton matching the team list layout

## Test plan
- [x] Trigger a toast: copy a league invite link on the league page — should show bottom-right toast instead of browser alert
- [x] Verify login still works (getUser change)
- [x] Check auth button text color adapts across themes (no more hardcoded gray)
- [ ] Enable "Reduce motion" in OS accessibility settings — verify no animations play
- [ ] Resize league page to mobile width — commissioner buttons should wrap, weekly scores should hide
- [ ] Tab through the app — skip-to-content link should appear on first Tab press
- [ ] Navigate to home page with slow connection / loading state — should show skeleton cards

🤖 Generated with [Claude Code](https://claude.ai/code)