### PR TITLE
feat: add position color coding to team roster page

### DIFF
--- a/app/league/[id]/team/[teamid]/one-team.tsx
+++ b/app/league/[id]/team/[teamid]/one-team.tsx
@@ -6,6 +6,7 @@ import { useCallback, useMemo } from 'react';
 import Image from 'next/image';
 import { calculatePlayerScore } from '../../../../utils/scoring';
 import { Card, CardContent } from "@/components/ui/card";
+import { getPositionColor, getPositionBorderColor } from '../../../../draft/[id]/utils';
 
 export default function OneTeam({ team }: { team: TeamWithPlayers & { leagues: League } }) {
     const orderedPlayers = useCallback(() => {
@@ -65,6 +66,7 @@ export default function OneTeam({ team }: { team: TeamWithPlayers & { leagues: L
                     <div
                         key={player.id}
                         className={`flex items-center p-4 bg-background rounded-lg border border-border hover:border-accent transition-colors ${player.eliminated ? 'opacity-50' : ''}`}
+                        style={{ borderLeft: `3px solid ${getPositionBorderColor(player.position, team.leagues?.league || 'NFL')}` }}
                     >
                         <div className="flex-shrink-0">
                             <Image
@@ -88,7 +90,7 @@ export default function OneTeam({ team }: { team: TeamWithPlayers & { leagues: L
                                 </div>
 
                                 <div className="text-right flex items-center gap-2">
-                                    <span className="inline-block px-2 py-1 bg-card rounded text-xs font-medium text-accent">
+                                    <span className={`inline-block px-2 py-1 rounded text-xs font-bold text-white ${getPositionColor(player.position, team.leagues?.league || 'NFL')}`}>
                                         {player.position}
                                     </span>
                                     {player.eliminated && (


### PR DESCRIPTION
## Summary
- Add colored left border on player rows using draft page's `getPositionBorderColor()` utility
- Replace plain position badge with colored badge using `getPositionColor()` to match draft page style
- Supports NFL (QB=red, RB=blue, WR=green, TE=yellow, K=purple, DEF=orange) and NBA/NCAAM (G=green, F=yellow, C=blue)

## Test plan
- [ ] View an NFL team roster and verify position badges and left borders match draft page colors
- [ ] View an NBA/NCAAM team roster and verify position colors are correct
- [ ] Verify eliminated players still show opacity styling with colors

🤖 Generated with [Claude Code](https://claude.ai/code)