### PR TITLE
fix: derive NCAAM elimination from ncaa_team_info

### DIFF
--- a/app/league/[id]/page.tsx
+++ b/app/league/[id]/page.tsx
@@ -201,17 +201,26 @@ export default async function League(props: { params: Promise<{ id: LeagueID }> 
     });
     const sortedWeeks = Array.from(allWeeks).sort((a, b) => a - b);
 
-    // For NCAAM Best Ball, fetch eliminated status for all rostered players
+    // For NCAAM Best Ball, fetch eliminated status from ncaa_team_info
     let playerEliminated: Record<string, boolean> = {};
     if (leagueData.league === 'NCAAM') {
         const allPlayerIds = teamsData.flatMap(t => t.team_players || []);
         if (allPlayerIds.length > 0) {
-            const { data: playerStatuses } = await supabase
+            // Get player team_names
+            const { data: playerTeams } = await supabase
                 .from('players')
-                .select('id, eliminated')
+                .select('id, team_name')
                 .in('id', allPlayerIds);
-            (playerStatuses || []).forEach(p => {
-                playerEliminated[p.id] = p.eliminated ?? false;
+            // Get eliminated teams from ncaa_team_info
+            const teamNames = [...new Set((playerTeams || []).map(p => p.team_name))];
+            const { data: eliminatedTeams } = await supabase
+                .from('ncaa_team_info')
+                .select('team_name')
+                .in('team_name', teamNames)
+                .eq('eliminated', true);
+            const eliminatedSet = new Set((eliminatedTeams || []).map(t => t.team_name));
+            (playerTeams || []).forEach(p => {
+                playerEliminated[p.id] = eliminatedSet.has(p.team_name);
             });
         }
     }

--- a/app/league/[id]/team/[teamid]/one-team.tsx
+++ b/app/league/[id]/team/[teamid]/one-team.tsx
@@ -115,7 +115,7 @@ export default function OneTeam({ team }: { team: TeamWithPlayers & { leagues: L
                                                      WebkitMaskImage: 'linear-gradient(to right, black 90%, transparent 100%)'
                                                  }}>
                                                 <div className="flex whitespace-nowrap text-muted-foreground text-sm pr-4">
-                                                    {player.gameStats.map((stat : GameStats, index: number) => {
+                                                    {[...player.gameStats].sort((a: GameStats, b: GameStats) => (a.week_number || 0) - (b.week_number || 0)).map((stat : GameStats, index: number) => {
                                                         const gameScore = calculatePlayerScore([stat], team.leagues, player.position).toFixed(1);
                                                         return (
                                                             <div key={stat.id} className="mr-2 flex-shrink-0 text-center">

--- a/app/league/[id]/team/[teamid]/page.tsx
+++ b/app/league/[id]/team/[teamid]/page.tsx
@@ -124,11 +124,24 @@ export default async function Team(props: { params: Promise<{ teamid: TeamID }> 
         totalScore
     };
     
+    // For NCAAM leagues, fetch eliminated status from ncaa_team_info
+    let eliminatedTeams: Set<string> = new Set();
+    if (team.leagues?.league === 'NCAAM' && players && players.length > 0) {
+        const teamNames = [...new Set(players.map(p => p.team_name))];
+        const { data: teamInfos } = await supabase
+            .from('ncaa_team_info')
+            .select('team_name, eliminated')
+            .in('team_name', teamNames)
+            .eq('eliminated', true);
+        (teamInfos || []).forEach(t => eliminatedTeams.add(t.team_name));
+    }
+
     // Map game stats to respective players
     const playersWithStats = players?.map(player => {
         const playerGameStats = allPlayersGameStats?.filter(stat => stat.player_id === player.id) || [];
         return {
             ...player,
+            eliminated: team.leagues?.league === 'NCAAM' ? eliminatedTeams.has(player.team_name) : (player.eliminated ?? false),
             gameStats: playerGameStats
         };
     }) || [];

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -16,28 +16,31 @@ export type Database = {
     Tables: {
       ncaa_team_info: {
         Row: {
+          created_at: string | null
+          eliminated: boolean | null
           id: string
-          team_name: string
-          seed: number | null
           region: string | null
           season_year: number
-          created_at: string | null
+          seed: number | null
+          team_name: string
         }
         Insert: {
+          created_at?: string | null
+          eliminated?: boolean | null
           id?: string
-          team_name: string
-          seed?: number | null
           region?: string | null
           season_year?: number
-          created_at?: string | null
+          seed?: number | null
+          team_name: string
         }
         Update: {
+          created_at?: string | null
+          eliminated?: boolean | null
           id?: string
-          team_name?: string
-          seed?: number | null
           region?: string | null
           season_year?: number
-          created_at?: string | null
+          seed?: number | null
+          team_name?: string
         }
         Relationships: []
       }


### PR DESCRIPTION
## Summary
- Derive player eliminated status from `ncaa_team_info.eliminated` instead of `players.eliminated` on both the league page and team page
- Sort game stats (G1, G2, G3...) in ascending order by week number on the team roster
- Regenerate database types to include `eliminated` column on `ncaa_team_info`

## Test plan
- [x] Open an NCAAM league page — verify eliminated player counts reflect `ncaa_team_info.eliminated`
- [x] Open a team page in an NCAAM league — verify players from eliminated teams show the "Eliminated" badge and dimmed styling
- [x] Verify game stat pills display in ascending order (G1, G2, G3...)

🤖 Generated with [Claude Code](https://claude.ai/code)